### PR TITLE
Fix the wrong module being imported.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,8 @@ def fix_syspath(tmp_path):
     """
     This is the current solution to the empty string being missing
     from sys.path when running pytest."""
-    old_path = sys.path
+    old_path = sys.path.copy()
+    old_dir = os.getcwd()
     old_modules = dict(sys.modules)
     sys.path.insert(0, "")
     os.chdir(tmp_path)
@@ -18,3 +19,4 @@ def fix_syspath(tmp_path):
         if module not in old_modules:
             del sys.modules[module]
     sys.path = old_path
+    os.chdir(old_dir)

--- a/tests/utils/test_importer.py
+++ b/tests/utils/test_importer.py
@@ -54,7 +54,7 @@ error_cases = [
     },
     {
         # Tests the except block on line 65
-        "module": "fake_module_4",
+        "module": "fake_module",
         "error": ModuleNotFoundError,
         "message": "Error while importing `fake_obj`",
         "object": "fake_obj",

--- a/tests/utils/test_user.py
+++ b/tests/utils/test_user.py
@@ -95,7 +95,7 @@ call_obj_pass = [
     },
     {
         "options": Options(sub_module="input_user", entries=("Jack",)),
-        "module": "input_user_1",
+        "module": "input_user",
         "file_text": "def main():\n    name = input('What is your name? ')\n    print(f'Hello, {name}!')",
         "result": "What is your name? Jack\nHello, Jack!\n",
     },
@@ -193,7 +193,7 @@ call_obj_fail = [
     },
     {  # Exit function
         "options": Options(sub_module="hello_user"),
-        "module": "hello_user_5",
+        "module": "hello_user",
         "file_text": "def main():\n     print('Hello, User!')\n     exit()",
         "result": "Hello, User!\n",
         "error": ExitError,


### PR DESCRIPTION
Fixes the `fix_syspath` fixture to allow for fake modules with the same name as other modules. This was an issue because after a module was imported, its name and contents were stored in `sys.modules`. This caused any future imports with the same name to refer to the older imported version.