### PR TITLE
Centralize text wrapping

### DIFF
--- a/src/generic_grader/file/file_closed.py
+++ b/src/generic_grader/file/file_closed.py
@@ -1,14 +1,13 @@
 """Test that all files are closed."""
 
 import functools
-import textwrap
 import unittest
 import warnings
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
-from generic_grader.utils.docs import make_call_str, oxford_list
+from generic_grader.utils.docs import get_wrapper, make_call_str, oxford_list
 from generic_grader.utils.options import options_to_params
 from generic_grader.utils.reference_test import reference_test
 
@@ -48,7 +47,7 @@ def build(the_options):
     class TestFileClosed(unittest.TestCase):
         """A class for file closing tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted

--- a/src/generic_grader/file/file_has_n_lines.py
+++ b/src/generic_grader/file/file_has_n_lines.py
@@ -1,12 +1,11 @@
 """Test the number of lines in a file."""
 
-import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
-from generic_grader.utils.docs import make_call_str, oxford_list
+from generic_grader.utils.docs import get_wrapper, make_call_str, oxford_list
 from generic_grader.utils.options import options_to_params
 from generic_grader.utils.reference_test import reference_test
 
@@ -38,7 +37,7 @@ def build(options):
     class TestFileHasNLines(unittest.TestCase):
         """A class for functionality tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted

--- a/src/generic_grader/file/file_lines_are_random.py
+++ b/src/generic_grader/file/file_lines_are_random.py
@@ -1,13 +1,12 @@
 """Test that the values written to a file are random."""
 
 import os
-import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
-from generic_grader.utils.docs import make_call_str, oxford_list
+from generic_grader.utils.docs import get_wrapper, make_call_str, oxford_list
 from generic_grader.utils.options import options_to_params
 from generic_grader.utils.reference_test import reference_test
 from generic_grader.utils.user import SubUser
@@ -42,7 +41,7 @@ def build(options):
     class TestFileLinesAreRandom(unittest.TestCase):
         """A class for functionality tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted

--- a/src/generic_grader/file/file_lines_match_reference.py
+++ b/src/generic_grader/file/file_lines_match_reference.py
@@ -1,12 +1,11 @@
 """Test that the lines written to a file match a reference."""
 
-import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
-from generic_grader.utils.docs import make_call_str, oxford_list
+from generic_grader.utils.docs import get_wrapper, make_call_str, oxford_list
 from generic_grader.utils.options import options_to_params
 from generic_grader.utils.reference_test import reference_test
 
@@ -39,7 +38,7 @@ def build(the_options):
     class TestFileLinesMatchReference(unittest.TestCase):
         """A class for functionality tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted

--- a/src/generic_grader/file/file_lines_span_range.py
+++ b/src/generic_grader/file/file_lines_span_range.py
@@ -1,12 +1,11 @@
 """Test the range of random values that are written to a file."""
 
-import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
-from generic_grader.utils.docs import make_call_str, oxford_list
+from generic_grader.utils.docs import get_wrapper, make_call_str, oxford_list
 from generic_grader.utils.options import options_to_params
 from generic_grader.utils.reference_test import reference_test
 
@@ -41,7 +40,7 @@ def build(options):
     class TestFileLinesSpanRange(unittest.TestCase):
         """A class for functionality tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted

--- a/src/generic_grader/file/file_presence.py
+++ b/src/generic_grader/file/file_presence.py
@@ -1,13 +1,13 @@
 """Test for presence of required files."""
 
 import glob
-import textwrap
 import unittest
 from pathlib import Path
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
+from generic_grader.utils.docs import get_wrapper
 from generic_grader.utils.options import options_to_params
 
 # TODO
@@ -42,7 +42,7 @@ def build(the_options):
     class TestFilePresence(unittest.TestCase):
         """A class for file tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         @parameterized.expand(the_params, doc_func=lambda func, n, p: func.__doc__)
         @weighted

--- a/src/generic_grader/function/function_return_values_match_reference.py
+++ b/src/generic_grader/function/function_return_values_match_reference.py
@@ -1,12 +1,11 @@
 """Test calculation results."""
 
-import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
-from generic_grader.utils.docs import make_call_str
+from generic_grader.utils.docs import get_wrapper, make_call_str
 from generic_grader.utils.options import options_to_params
 from generic_grader.utils.reference_test import reference_test
 
@@ -35,7 +34,7 @@ def build(the_options):
     class TestFunctionReturnValuesMatchReference(unittest.TestCase):
         """A class for functionality tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted

--- a/src/generic_grader/image/ocr_words_match_reference.py
+++ b/src/generic_grader/image/ocr_words_match_reference.py
@@ -1,7 +1,6 @@
 """Test calculation results."""
 
 import difflib
-import textwrap
 import unittest
 
 import pytesseract
@@ -9,6 +8,7 @@ from parameterized import parameterized
 from PIL import Image
 
 from generic_grader.utils.decorators import weighted
+from generic_grader.utils.docs import get_wrapper
 from generic_grader.utils.options import options_to_params
 
 
@@ -30,7 +30,7 @@ def build(options):
     class OCRWordsMatchReference(unittest.TestCase):
         """A class for functionality tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted

--- a/src/generic_grader/output/output_lines_match_reference.py
+++ b/src/generic_grader/output/output_lines_match_reference.py
@@ -1,12 +1,11 @@
 """Test the output lines of a function."""
 
-import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
-from generic_grader.utils.docs import make_call_str, make_line_range
+from generic_grader.utils.docs import get_wrapper, make_call_str, make_line_range
 from generic_grader.utils.options import options_to_params
 from generic_grader.utils.reference_test import reference_test
 
@@ -36,7 +35,7 @@ def build(the_options):
     class TestOutputLinesMatchReference(unittest.TestCase):
         """A class for formatting tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted

--- a/src/generic_grader/output/output_values_match_reference.py
+++ b/src/generic_grader/output/output_values_match_reference.py
@@ -1,12 +1,11 @@
 """Test all values in the output from a function."""
 
-import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
-from generic_grader.utils.docs import make_call_str, ordinalize
+from generic_grader.utils.docs import get_wrapper, make_call_str, ordinalize
 from generic_grader.utils.options import options_to_params
 from generic_grader.utils.reference_test import reference_test
 
@@ -38,7 +37,7 @@ def build(the_options):
     class TestOutputValuesMatchReference(unittest.TestCase):
         """A class for formatting tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted

--- a/src/generic_grader/style/comments.py
+++ b/src/generic_grader/style/comments.py
@@ -1,12 +1,12 @@
 """Test for appropriate comment length."""
 
 import os
-import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
+from generic_grader.utils.docs import get_wrapper
 from generic_grader.utils.options import options_to_params
 from generic_grader.utils.static import get_comments
 
@@ -25,6 +25,8 @@ def build(the_options):
     class TestCommentLength(unittest.TestCase):
         """A class for comment length check."""
 
+        wrapper = get_wrapper()
+
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted
         def test_comment_length(self, options):
@@ -39,14 +41,14 @@ def build(the_options):
             expected = sum([len(c) for c in ref_body_comments])
 
             minimum = max(int(0.5 * expected), 10)  # Require at least 10 characters.
-            message = "\n\nHint:\n" + textwrap.fill(
+            message = "\n\nHint:\n" + self.wrapper.fill(
                 "Your program has too few comments."
                 "  Add more comments to better explain your code."
             )
             self.assertGreaterEqual(actual, minimum, msg=message)
 
             maximum = max(int(5 * expected), 100)  # Always allow up to 100 characters.
-            message = "\n\nHint:\n" + textwrap.fill(
+            message = "\n\nHint:\n" + self.wrapper.fill(
                 "Your program has a lot of comments."
                 "  See if you can make your comments more concise."
             )

--- a/src/generic_grader/style/docstring.py
+++ b/src/generic_grader/style/docstring.py
@@ -3,12 +3,12 @@
 import ast
 import datetime
 import os
-import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
+from generic_grader.utils.docs import get_wrapper
 from generic_grader.utils.options import options_to_params
 
 
@@ -60,7 +60,7 @@ def build(the_options):
     class TestDocstring(unittest.TestCase):
         """A class for docstring tests."""
 
-        wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+        wrapper = get_wrapper()
 
         def set_up(self):
             with open(submission) as fo:

--- a/src/generic_grader/style/program_length.py
+++ b/src/generic_grader/style/program_length.py
@@ -1,12 +1,12 @@
 """Test for appropriate program length."""
 
 import os
-import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from generic_grader.utils.decorators import weighted
+from generic_grader.utils.docs import get_wrapper
 from generic_grader.utils.options import options_to_params
 from generic_grader.utils.static import get_tokens
 
@@ -25,6 +25,8 @@ def build(the_options):
     class TestProgramLength(unittest.TestCase):
         """A class for program length check."""
 
+        wrapper = get_wrapper()
+
         # TODO: enable partial credit when program is only a little too long
         @parameterized.expand(the_params, doc_func=doc_func)
         @weighted
@@ -38,7 +40,7 @@ def build(the_options):
             expected = len(get_tokens(self, reference_file))
 
             maximum = int(2 * expected)
-            message = "\n\nHint:\n" + textwrap.fill(
+            message = "\n\nHint:\n" + self.wrapper.fill(
                 "Your program is a lot bigger than expected."
                 "  See if you can redesign it to use less code."
             )
@@ -46,7 +48,7 @@ def build(the_options):
 
             self.set_score(self, options.weight)  # Full credit.
             maximum = int(1.5 * expected)
-            message = "\n\nHint:\n" + textwrap.fill(
+            message = "\n\nHint:\n" + self.wrapper.fill(
                 "Your program is a bit bigger than expected."
                 "  See if you can redesign it to use less code."
             )

--- a/src/generic_grader/utils/docs.py
+++ b/src/generic_grader/utils/docs.py
@@ -1,5 +1,7 @@
 """Functions to generate customized docstrings for parameterized tests."""
 
+import textwrap
+
 
 def make_call_str(func_name="main", args=[], kwargs={}):
     """Construct and return a function call string from its name, and
@@ -58,3 +60,8 @@ def oxford_list(sequence):
         last = sequence[-1]
         not_last = ", ".join(sequence[:-1])
         return f"{not_last}, and {last}"
+
+
+def get_wrapper() -> textwrap.TextWrapper:
+    """Return an instance of the text wrapper used across tests."""
+    return textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")

--- a/src/generic_grader/utils/exceptions.py
+++ b/src/generic_grader/utils/exceptions.py
@@ -1,14 +1,12 @@
-import textwrap
 import traceback
 from os import path
+
+from generic_grader.utils.docs import get_wrapper
 
 inf_loop_hint = "Make sure your program isn't stuck in an infinite loop."
 return_hint = "Try using a `return` statement instead."
 
-wrapper = textwrap.TextWrapper(
-    initial_indent="  ",
-    subsequent_indent="  ",
-)
+wrapper = get_wrapper()
 
 
 def indent(string, pad="  "):

--- a/src/generic_grader/utils/importer.py
+++ b/src/generic_grader/utils/importer.py
@@ -1,16 +1,16 @@
 """Handle importing objects from student code."""
 
-import textwrap
 import unittest
 from unittest.mock import patch
 
+from generic_grader.utils.docs import get_wrapper
 from generic_grader.utils.exceptions import handle_error
 
 
 class Importer:
     """A class for object import handling."""
 
-    wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+    wrapper = get_wrapper()
 
     class InputError(Exception):
         """Custom Exception type."""

--- a/src/generic_grader/utils/reference_test.py
+++ b/src/generic_grader/utils/reference_test.py
@@ -3,15 +3,14 @@
 import difflib
 import functools
 import os
-import textwrap
 
 from attrs import evolve
 
-from generic_grader.utils.docs import calc_log_limit, make_call_str
+from generic_grader.utils.docs import calc_log_limit, get_wrapper, make_call_str
 from generic_grader.utils.exceptions import RefFileNotFoundError
 from generic_grader.utils.user import RefUser, SubUser
 
-text_wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+text_wrapper = get_wrapper()
 
 
 def reference_test(func):

--- a/src/generic_grader/utils/user.py
+++ b/src/generic_grader/utils/user.py
@@ -4,7 +4,6 @@ import re
 import resource
 import signal
 import sys
-import textwrap
 from contextlib import ExitStack, contextmanager
 from copy import deepcopy
 from io import StringIO
@@ -13,7 +12,7 @@ from unittest.mock import patch
 from attrs import evolve
 from freezegun import freeze_time
 
-from generic_grader.utils.docs import make_call_str, ordinalize
+from generic_grader.utils.docs import get_wrapper, make_call_str, ordinalize
 from generic_grader.utils.exceptions import (
     EndOfInputError,
     ExitError,
@@ -93,7 +92,7 @@ def memory_limit(max_gibibytes):
 class __User__:
     """Manages interactions with parts of the submitted code."""
 
-    wrapper = textwrap.TextWrapper(initial_indent="  ", subsequent_indent="  ")
+    wrapper = get_wrapper()
 
     class LogIO(StringIO):
         """A string io object with a character limit."""

--- a/tests/utils/test_docs.py
+++ b/tests/utils/test_docs.py
@@ -1,7 +1,10 @@
+import textwrap
+
 import pytest
 
 from generic_grader.utils.docs import (
     calc_log_limit,
+    get_wrapper,
     make_call_str,
     make_line_range,
     ordinalize,
@@ -112,3 +115,12 @@ oxford_cases = [
 def test_oxford_list(case):
     """Test oxford_list to ensure it formats lists correctly."""
     assert oxford_list(case["sequence"]) == case["expected"]
+
+
+def test_get_wrapper():
+    """Test get_wrapper to ensure it returns the correct wrapper."""
+    wrapper = get_wrapper()
+    assert isinstance(wrapper, textwrap.TextWrapper)
+
+    assert wrapper.initial_indent == "  "
+    assert wrapper.subsequent_indent == "  "


### PR DESCRIPTION
Create a function that returns a textwrapper, instead of creating one inside of every test. All use this wrapper in places where we were using a generic text-wrapper. Is the first part of #38 