### PR TITLE
Factor out stack management into a custom context manager

### DIFF
--- a/src/generic_grader/utils/patches.py
+++ b/src/generic_grader/utils/patches.py
@@ -1,3 +1,8 @@
+from contextlib import ExitStack, contextmanager
+from unittest.mock import patch
+
+from freezegun import freeze_time
+
 from generic_grader.utils.exceptions import (
     ExitError,
     QuitError,
@@ -8,6 +13,8 @@ from generic_grader.utils.mocks import (
     make_mock_function_noop,
     make_mock_function_raise_error,
 )
+from generic_grader.utils.options import Options
+from generic_grader.utils.resource_limits import memory_limit, time_limit
 
 
 def make_turtle_done_patches(modules):
@@ -48,10 +55,31 @@ def make_pyplot_noop_patches(modules):
 
 
 def make_exit_quit_patches():
-    """Patch `sys.exit` and `quit`"""
+    """Patch the builtins exit and quit functions."""
     return [
         {
             "args": make_mock_function_raise_error("builtins.exit", ExitError),
         },
         {"args": make_mock_function_raise_error("builtins.quit", QuitError)},
     ]
+
+
+@contextmanager
+def custom_stack(o: Options):
+    """Create a custom stack with resource limits and patches."""
+    with ExitStack() as stack:
+        # Add custom resource limits
+        stack.enter_context(time_limit(o.time_limit))
+        stack.enter_context(memory_limit(o.memory_limit_GB))
+        if o.fixed_time:
+            stack.enter_context(freeze_time(o.fixed_time))
+        patches = (o.patches or []) + make_exit_quit_patches()
+        for p in patches:
+            stack.enter_context(
+                patch(
+                    *p.get("args", ()),  # permit missing args
+                    **p.get("kwargs", {}),  # permit missing kwargs
+                )
+            )
+
+        yield


### PR DESCRIPTION
Move stack custom stack creation from user and importer into one place.
This has created a few unneeded test cases inside of importer and user, however I do not any downside in removing tests at the moment, especially since these "duplicate tests" will allow for a quick way to tell where something may have possibly gone wrong in the future.