### PR TITLE
Fix raise_input_error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "generic-grader"
-version = "0.1.20"
+version = "0.1.21"
 authors = [
     { name = "John Cole", email = "jhcole@purdue.edu" },
     { name = "Jack Scarfo", email = "jscarfo@purdue.edu" },

--- a/src/generic_grader/utils/importer.py
+++ b/src/generic_grader/utils/importer.py
@@ -19,7 +19,7 @@ class Importer:
         """Custom Exception type."""
 
     @classmethod
-    def raise_input_error(cls):
+    def raise_input_error(cls, *args, **kwargs):
         """Raise our custom exception."""
         raise cls.InputError()
 

--- a/tests/utils/test_importer.py
+++ b/tests/utils/test_importer.py
@@ -69,6 +69,14 @@ error_cases = [
         "object": "fake_func",
     },
     {
+        # Tests the except block on line 51
+        "module": "fake_module",
+        "error": Importer.InputError,
+        "text": "input('foo', bar='spam')\nfake_func = lambda: None",
+        "message": "Stuck at call to `input()` while importing `fake_func`",
+        "object": "fake_func",
+    },
+    {
         # Tests the except block on line 65
         "module": "fake_module",
         "error": ModuleNotFoundError,


### PR DESCRIPTION
In python3.12.8 they fixed this [bug](https://github.com/python/cpython/issues/102978) that was causing methods decorated as class methods to not correctly match the function signatures they were being patched as. This bug was throwing away any extra arguments and allowed for us to patch input without collecting any arguments.