### PR TITLE
Fix grader machinery leaking into student tracebacks

### DIFF
--- a/src/generic_grader/utils/exceptions.py
+++ b/src/generic_grader/utils/exceptions.py
@@ -40,18 +40,24 @@ def format_error_msg(error_msg, hint=None):
     return f"{wrapper.fill(error_msg)}{hint}"
 
 
-# TODO: Fix problem where some filepaths still show up in the error message
 def handle_error(e, error_msg):
     stack_summary = traceback.extract_tb(e.__traceback__)
     short_stack_summary = []
     for frame_summary in stack_summary:
         dirname, filename = path.split(frame_summary.filename)
 
-        # Skip frames from the autograding system. This is usually the
-        # first frame, which contains the call to the submitted code in
-        # this try block, and the last 1 or 2 frames which typically
-        # contain the patched function.
-        if "/tests" in dirname or "/usr" in dirname or filename == "<string>":
+        # Skip frames from the autograding system. This includes:
+        # - /tests: test runner frames
+        # - /usr: system Python library frames
+        # - <string>: dynamically compiled code
+        # - generic_grader: the grader package itself (e.g., when
+        #   installed via uv into a virtualenv)
+        if (
+            "/tests" in dirname
+            or "/usr" in dirname
+            or "generic_grader" in dirname
+            or filename == "<string>"
+        ):
             continue
 
         # Remove the path information from the filename in each frame
@@ -62,7 +68,6 @@ def handle_error(e, error_msg):
         short_stack_summary.append(frame_summary)
 
     # Format the traceback with special handling for syntax errors.
-    # TODO: Fix problem where some filepaths still show up in the error message
     if isinstance(e, SyntaxError):
         # Remove the path information from the filename.
         dirname, filename = path.split(e.filename)

--- a/tests/utils/test_exceptions.py
+++ b/tests/utils/test_exceptions.py
@@ -18,8 +18,6 @@ from generic_grader.utils.exceptions import (
     wrapper,
 )
 
-# TODO Add a test for the handle_error function. This was left out because the function needs to be changed after partiy is achieved.
-
 
 def test_wrapper():
     """Test the wrapper that is used to format error messages."""

--- a/tests/utils/test_handle_error.py
+++ b/tests/utils/test_handle_error.py
@@ -1,0 +1,217 @@
+"""Tests for handle_error traceback filtering.
+
+Issue #163: Grader machinery frames (e.g., from generic_grader package)
+leak into student-facing tracebacks when generic-grader is installed
+in a virtualenv where paths don't contain '/usr' or '/tests'.
+"""
+
+import traceback
+from unittest.mock import patch
+
+from generic_grader.utils.exceptions import handle_error
+
+
+def _make_frame_summaries(filenames):
+    """Create a list of FrameSummary objects with the given filenames.
+
+    Each frame simulates a stack frame at the specified file path with
+    a line number and function name.
+    """
+    return [
+        traceback.FrameSummary(fn, lineno=i + 1, name=f"func_{i}")
+        for i, fn in enumerate(filenames)
+    ]
+
+
+def _raise_with_filenames(filenames):
+    """Create a real exception and patch extract_tb to return controlled frames.
+
+    This lets us test handle_error's filtering logic with arbitrary
+    file paths without needing to construct real traceback objects.
+    """
+    try:
+        raise KeyError("test")
+    except KeyError as e:
+        frames = _make_frame_summaries(filenames)
+        with patch(
+            "generic_grader.utils.exceptions.traceback.extract_tb", return_value=frames
+        ):
+            return handle_error(e, "\nError message.")
+
+
+class TestHandleErrorFiltering:
+    """Test that handle_error filters out grader machinery frames."""
+
+    def test_filters_tests_directory_frames(self):
+        """Frames from /tests directories should be filtered out."""
+        result = _raise_with_filenames(
+            [
+                "/autograder/source/tests/test_something.py",
+                "/autograder/source/submission/student.py",
+            ]
+        )
+        assert "test_something.py" not in result
+        assert "student.py" in result
+
+    def test_filters_usr_directory_frames(self):
+        """Frames from /usr directories (system Python) should be filtered out."""
+        result = _raise_with_filenames(
+            [
+                "/usr/lib/python3.13/ast.py",
+                "/autograder/source/submission/student.py",
+            ]
+        )
+        assert "ast.py" not in result
+        assert "student.py" in result
+
+    def test_filters_string_filename(self):
+        """Frames from <string> (dynamically compiled code) should be filtered out."""
+        result = _raise_with_filenames(
+            [
+                "<string>",
+                "/autograder/source/submission/student.py",
+            ]
+        )
+        assert 'File "<string>"' not in result
+        assert "student.py" in result
+
+    def test_filters_generic_grader_virtualenv_frames(self):
+        """Frames from generic_grader package in a virtualenv should be filtered.
+
+        This is the core bug from issue #163: when generic-grader is
+        installed via uv into a virtualenv, paths like
+        /autograder/source/.venv/lib/.../generic_grader/utils/user.py
+        don't contain '/tests' or '/usr', so they leak through.
+        """
+        result = _raise_with_filenames(
+            [
+                "/autograder/source/.venv/lib/python3.13/site-packages/generic_grader/utils/user.py",
+                "/autograder/source/submission/course_info.py",
+            ]
+        )
+        assert "user.py" not in result
+        assert "course_info.py" in result
+
+    def test_filters_generic_grader_editable_install_frames(self):
+        """Frames from generic_grader in an editable install should be filtered."""
+        result = _raise_with_filenames(
+            [
+                "/autograder/source/generic_grader/utils/user.py",
+                "/autograder/source/submission/student.py",
+            ]
+        )
+        assert "user.py" not in result
+        assert "student.py" in result
+
+    def test_keeps_only_student_code_frames(self):
+        """Only student code frames should remain in the traceback.
+
+        Simulates the exact scenario from issue #163: a student's
+        course_info.py raises a KeyError, and the traceback should
+        show only their frame.
+        """
+        result = _raise_with_filenames(
+            [
+                "/autograder/source/.venv/lib/python3.13/site-packages/generic_grader/utils/user.py",
+                "/autograder/source/submission/course_info.py",
+                "/autograder/source/.venv/lib/python3.13/site-packages/generic_grader/utils/patches.py",
+            ]
+        )
+        assert "user.py" not in result
+        assert "patches.py" not in result
+        assert "course_info.py" in result
+        assert "Traceback (most recent call last):" in result
+
+    def test_empty_traceback_when_all_frames_filtered(self):
+        """When all frames are internal, no traceback header should appear."""
+        result = _raise_with_filenames(
+            [
+                "/autograder/source/tests/test_something.py",
+                "/usr/lib/python3.13/something.py",
+            ]
+        )
+        assert "Traceback (most recent call last):" not in result
+        # But the exception itself should still appear
+        assert "KeyError" in result
+
+    def test_strips_path_from_student_frames(self):
+        """Student frame filenames should have directory paths removed."""
+        result = _raise_with_filenames(
+            [
+                "/autograder/source/submission/my_program.py",
+            ]
+        )
+        # The full path should not appear
+        assert "/autograder/source/submission/" not in result
+        # But the filename should
+        assert "my_program.py" in result
+
+
+class TestHandleErrorSyntaxError:
+    """Test SyntaxError special handling in handle_error."""
+
+    def test_syntax_error_path_stripped(self):
+        """SyntaxError.filename should have its directory path removed."""
+        try:
+            raise SyntaxError(
+                "invalid syntax",
+                ("/autograder/source/submission/student.py", 5, 10, "x = "),
+            )
+        except SyntaxError as e:
+            frames = _make_frame_summaries(
+                ["/autograder/source/tests/test_something.py"]
+            )
+            with patch(
+                "generic_grader.utils.exceptions.traceback.extract_tb",
+                return_value=frames,
+            ):
+                result = handle_error(e, "\nSyntax error in your code.")
+            assert "/autograder/source/submission/" not in result
+            assert "student.py" in result
+
+    def test_syntax_error_with_generic_grader_path(self):
+        """SyntaxError from within generic_grader should also be handled."""
+        try:
+            raise SyntaxError(
+                "invalid syntax",
+                (
+                    "/autograder/source/.venv/lib/python3.13/site-packages/generic_grader/utils/something.py",
+                    5,
+                    10,
+                    "x = ",
+                ),
+            )
+        except SyntaxError as e:
+            frames = _make_frame_summaries(
+                [
+                    "/autograder/source/.venv/lib/python3.13/site-packages/generic_grader/utils/something.py"
+                ]
+            )
+            with patch(
+                "generic_grader.utils.exceptions.traceback.extract_tb",
+                return_value=frames,
+            ):
+                result = handle_error(e, "\nSyntax error.")
+            # The generic_grader path should be stripped
+            assert "site-packages" not in result
+
+
+class TestHandleErrorOutput:
+    """Test the output format of handle_error."""
+
+    def test_output_is_indented(self):
+        """The output should be indented with two spaces."""
+        result = _raise_with_filenames(["/autograder/source/submission/student.py"])
+        # Each line should start with two spaces (indent function)
+        for line in result.splitlines():
+            assert line.startswith("  "), f"Line not indented: {line!r}"
+
+    def test_error_msg_appears_in_output(self):
+        """The error_msg parameter should appear in the output."""
+        result = _raise_with_filenames(["/autograder/source/submission/student.py"])
+        assert "Error message." in result
+
+    def test_exception_type_appears_in_output(self):
+        """The exception type and message should appear in the output."""
+        result = _raise_with_filenames(["/autograder/source/submission/student.py"])
+        assert "KeyError" in result


### PR DESCRIPTION
## Problem

Closes #163.

When generic-grader is installed via `uv` into a virtualenv on Gradescope, the `handle_error` function in `exceptions.py` fails to filter out internal frames from the `generic_grader` package. This causes grader machinery (e.g., `File "user.py", line 253, in call_obj`) to appear in student-facing tracebacks.

### Root Cause

The frame filter at line 54 checks for `/tests` and `/usr` in the directory path, and `<string>` as the filename. However, when the package is installed in a virtualenv path like `/autograder/source/.venv/lib/python3.13/site-packages/generic_grader/utils/user.py`, none of these patterns match.

## Solution

Add `"generic_grader" in dirname` to the frame filtering condition. This catches all frames from the grader package regardless of installation method (virtualenv, editable install, or system-wide).

## Changes

- **`src/generic_grader/utils/exceptions.py`**: Add `generic_grader` path check to the frame filter in `handle_error`; remove two resolved TODO comments about filepath leaks
- **`tests/utils/test_handle_error.py`**: New comprehensive test suite for `handle_error` with 13 test cases covering:
  - Filtering of `/tests`, `/usr`, `<string>`, and `generic_grader` frames
  - Virtualenv and editable install path patterns
  - Student code frames preserved with paths stripped
  - SyntaxError special handling
  - Output format verification (indentation, error message, exception type)
- **`tests/utils/test_exceptions.py`**: Remove stale TODO about missing `handle_error` tests

## Testing

- 685 passed, 4 skipped
- 100% coverage on `exceptions.py`
- All pre-commit hooks pass