### PR TITLE
Fix memory limit to use relative RLIMIT_AS

### DIFF
--- a/src/generic_grader/utils/resource_limits.py
+++ b/src/generic_grader/utils/resource_limits.py
@@ -1,3 +1,4 @@
+import os
 import resource
 import signal
 import sys
@@ -29,19 +30,34 @@ def time_limit(seconds):
         signal.alarm(0)
 
 
+def _get_current_vm_bytes():
+    """Return the current virtual memory size of this process in bytes.
+
+    Reads VmSize from /proc/self/status, which represents the total
+    virtual address space used by the process.
+    """
+    with open(f"/proc/{os.getpid()}/status") as f:
+        for line in f:
+            if line.startswith("VmSize:"):
+                return int(line.split()[1]) * 1024  # kB to bytes
+    return 0  # pragma: no cover
+
+
 @contextmanager
 def memory_limit(max_gibibytes):
     """A context manager to limit memory usage while running submitted code.
-    For soft limits above 20 MiB, the error was found experimentally to be
-    raised when the total memory usage was about 10 MiB below the soft limit.
-    For all soft limits less than 20 MiB, the error was raised when the total
-    memory usage was about 9.2 MiB.
+
+    Sets RLIMIT_AS relative to the current virtual memory usage so that
+    the enclosed code gets exactly max_gibibytes of additional address
+    space, regardless of how much memory the Python runtime and its
+    libraries already consume.
     """
     GiB = 2**30
     max_bytes = int(max_gibibytes * GiB)
+    current_vm = _get_current_vm_bytes()
 
     soft, hard = resource.getrlimit(resource.RLIMIT_AS)
-    resource.setrlimit(resource.RLIMIT_AS, (max_bytes, hard))
+    resource.setrlimit(resource.RLIMIT_AS, (current_vm + max_bytes, hard))
     try:
         yield
     except MemoryError:

--- a/tests/utils/test_patches.py
+++ b/tests/utils/test_patches.py
@@ -152,7 +152,6 @@ def test_stack_timelimit():
                 time.sleep(1)
 
 
-@pytest.mark.skip(reason="Memory limit is not working on some systems (see #65).")
 def test_stack_memorylimit():
     """Test that the custom stack properly patches memory limit."""
     o = Options()

--- a/tests/utils/test_resource_limits.py
+++ b/tests/utils/test_resource_limits.py
@@ -3,7 +3,11 @@ import time
 import pytest
 
 from generic_grader.utils.exceptions import UserTimeoutError
-from generic_grader.utils.resource_limits import memory_limit, time_limit
+from generic_grader.utils.resource_limits import (
+    _get_current_vm_bytes,
+    memory_limit,
+    time_limit,
+)
 
 time_limit_cases = [
     {"length": 0.5, "result": None},
@@ -24,17 +28,28 @@ def test_time_limit(case):
             time.sleep(case["length"])
 
 
+def test_get_current_vm_bytes():
+    """Test that _get_current_vm_bytes returns a positive integer."""
+    vm_bytes = _get_current_vm_bytes()
+    assert isinstance(vm_bytes, int)
+    assert vm_bytes > 0
+
+
 memory_limit_cases = [
     {"usage": 0.5, "result": None},
-    {"usage": 1, "result": MemoryError},
+    {"usage": 1.5, "result": MemoryError},
     {"usage": 2, "result": MemoryError},
 ]
 
 
 @pytest.mark.parametrize("case", memory_limit_cases)
-@pytest.mark.skip(reason="Memory limit is not working on some systems (see #65).")
 def test_memory_limit(case):
-    """Test the memory_limit function."""
+    """Test the memory_limit function.
+
+    The limit is relative to current VM usage, so allocating
+    usage * GiB within a 1 GiB limit should succeed only when
+    usage is well below the limit.
+    """
     if case["result"] is not None:
         with pytest.raises(case["result"]):
             with memory_limit(1):
@@ -42,3 +57,35 @@ def test_memory_limit(case):
     else:
         with memory_limit(1):
             " " * int(case["usage"] * 2**30)
+
+
+def test_memory_limit_message():
+    """Test that the MemoryError includes a descriptive message."""
+    with pytest.raises(MemoryError, match="maximum allowed memory"):
+        with memory_limit(1):
+            " " * int(2 * 2**30)
+
+
+def test_memory_limit_restores_on_success():
+    """Test that RLIMIT_AS is restored after a successful block."""
+    import resource
+
+    soft_before, hard_before = resource.getrlimit(resource.RLIMIT_AS)
+    with memory_limit(1):
+        pass
+    soft_after, hard_after = resource.getrlimit(resource.RLIMIT_AS)
+    assert soft_before == soft_after
+    assert hard_before == hard_after
+
+
+def test_memory_limit_restores_on_error():
+    """Test that RLIMIT_AS is restored after a MemoryError."""
+    import resource
+
+    soft_before, hard_before = resource.getrlimit(resource.RLIMIT_AS)
+    with pytest.raises(MemoryError):
+        with memory_limit(1):
+            " " * int(2 * 2**30)
+    soft_after, hard_after = resource.getrlimit(resource.RLIMIT_AS)
+    assert soft_before == soft_after
+    assert hard_before == hard_after


### PR DESCRIPTION
## Problem

Closes #65.

`memory_limit()` in `resource_limits.py` uses `resource.RLIMIT_AS` to set an **absolute** limit on the total virtual address space. But `RLIMIT_AS` caps the entire process — including the Python runtime, loaded libraries (numpy, matplotlib, PIL), mmap regions, and glibc malloc arenas.

Since this baseline varies by system:
- **Lightweight container**: ~189 MiB — tests pass
- **Docker/Gradescope with heavier libs**: 500+ MiB — even a 0.2 GiB allocation can push total past 1 GiB, triggering unexpected `MemoryError`

This is exactly what the issue screenshot shows: `test_memory_limit[case0]` with `usage=0.2` fails because baseline VM + 0.2 GiB > 1 GiB absolute limit.

## Solution

Make the limit **relative** to current virtual memory usage:

1. Add `_get_current_vm_bytes()` — reads `VmSize` from `/proc/self/status`
2. Set `RLIMIT_AS` to `current_vm + max_bytes` instead of just `max_bytes`

This ensures the enclosed code always gets exactly `max_gibibytes` of additional address space, regardless of the process baseline.

## Changes

- **`src/generic_grader/utils/resource_limits.py`**: Add `_get_current_vm_bytes()` helper; update `memory_limit()` to set a relative limit
- **`tests/utils/test_resource_limits.py`**: Re-enable the 3 skipped `test_memory_limit` cases; add tests for `_get_current_vm_bytes`, error message content, and `RLIMIT_AS` restoration on both success and error paths
- **`tests/utils/test_patches.py`**: Re-enable `test_stack_memorylimit`

## Testing

- **693 passed, 0 skipped** (was 685 passed, 4 skipped)
- 100% coverage on `resource_limits.py`, `test_patches.py`, `test_resource_limits.py`
- All pre-commit hooks pass