### PR TITLE
Warn on ambiguous/missing file patterns and filter symlinks (#73)

### DIFF
--- a/src/generic_grader/utils/file_set_up.py
+++ b/src/generic_grader/utils/file_set_up.py
@@ -35,14 +35,16 @@ def file_set_up(options):
 
         if len(files) == 0:
             warnings.warn(
-                f'Cannot find any files matching the pattern "{file_pattern}".'
+                f'Cannot find any files matching the pattern "{file_pattern}".',
+                stacklevel=2,
             )
             continue
 
         if len(files) > 1:
             warnings.warn(
                 f'Found {len(files)} files matching the pattern "{file_pattern}":'
-                f" {files}.  Skipping symlink creation due to ambiguous match."
+                f" {files}.  Skipping symlink creation due to ambiguous match.",
+                stacklevel=2,
             )
             continue
 

--- a/src/generic_grader/utils/file_set_up.py
+++ b/src/generic_grader/utils/file_set_up.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import sys
+import warnings
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -23,9 +24,26 @@ def file_set_up(options):
             continue
 
         files = glob.glob(file_pattern)
-        files = [file for file in files if file not in o.ignored_files]
 
-        if len(files) != 1:  # src missing or ambiguous
+        # Exclude ignored files and existing symlinks so that stale
+        # symlinks from a previous run are not counted as matches.
+        files = [
+            file
+            for file in files
+            if file not in o.ignored_files and not Path(file).is_symlink()
+        ]
+
+        if len(files) == 0:
+            warnings.warn(
+                f'Cannot find any files matching the pattern "{file_pattern}".'
+            )
+            continue
+
+        if len(files) > 1:
+            warnings.warn(
+                f'Found {len(files)} files matching the pattern "{file_pattern}":'
+                f" {files}.  Skipping symlink creation due to ambiguous match."
+            )
             continue
 
         src = files[0]

--- a/tests/utils/test_file_set_up.py
+++ b/tests/utils/test_file_set_up.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import pytest
@@ -155,3 +156,71 @@ def test_init(capsys):
         pass
     captured = capsys.readouterr()
     assert captured.out == "init\n"
+
+
+def test_warns_on_missing_files(fix_syspath):
+    """Test that a warning is emitted when no files match a glob pattern."""
+    o = Options(required_files=("nonexistent*.py",))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with file_set_up(o):
+            pass
+    assert len(w) == 1
+    assert "nonexistent*.py" in str(w[0].message)
+
+
+def test_warns_on_ambiguous_files(fix_syspath):
+    """Test that a warning is emitted when multiple files match a glob pattern."""
+    (fix_syspath / "foo_login.py").write_text("")
+    (fix_syspath / "foot.py").write_text("")
+    o = Options(required_files=("foo*.py",))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with file_set_up(o):
+            pass
+    assert len(w) == 1
+    assert "foo*.py" in str(w[0].message)
+    assert "foo_login.py" in str(w[0].message)
+    assert "foot.py" in str(w[0].message)
+
+
+def test_no_warning_on_single_match(fix_syspath):
+    """Test that no warning is emitted when exactly one file matches."""
+    (fix_syspath / "foo_login.py").write_text("")
+    o = Options(required_files=("foo*.py",))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with file_set_up(o):
+            pass
+    assert len(w) == 0
+
+
+def test_no_warning_on_non_glob_pattern(fix_syspath):
+    """Test that no warning is emitted for non-glob required files."""
+    (fix_syspath / "foo.py").write_text("")
+    o = Options(required_files=("foo.py",))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with file_set_up(o):
+            pass
+    assert len(w) == 0
+
+
+def test_symlinks_excluded_from_glob(fix_syspath):
+    """Test that existing symlinks are excluded from glob results.
+
+    If a stale symlink exists from a previous run, it should not
+    be counted as a matching file.
+    """
+    # Create a real file and a stale symlink (the deglobbed name)
+    (fix_syspath / "foo_login.py").write_text("")
+    (fix_syspath / "foo.py").symlink_to("foo_login.py")
+
+    o = Options(required_files=("foo*.py",))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with file_set_up(o):
+            # The symlink should have been recreated (foo.py -> foo_login.py)
+            assert (fix_syspath / "foo.py").is_symlink()
+    # No warnings — the stale symlink was excluded, leaving exactly 1 real match
+    assert len(w) == 0


### PR DESCRIPTION
## Summary

Fixes #73.

`file_set_up()` previously silently skipped file patterns that matched zero or multiple files, making it difficult for instructors to diagnose configuration issues. It also counted stale symlinks from previous runs as glob matches, which could cause false ambiguity.

## Changes

### `src/generic_grader/utils/file_set_up.py`
- Emit a `warnings.warn()` when a glob pattern matches **no files**, with the pattern that failed.
- Emit a `warnings.warn()` when a glob pattern matches **multiple files**, listing the matches and explaining that symlink creation is skipped due to ambiguity.
- Filter out existing symlinks from glob results so that stale symlinks from a previous grading run are not counted as real matches.

### `tests/utils/test_file_set_up.py`
- `test_warns_on_missing_files` — verifies warning when no files match a pattern.
- `test_warns_on_ambiguous_files` — verifies warning when multiple files match, including the pattern and filenames in the message.
- `test_no_warning_on_single_match` — confirms no warning for the normal single-match case.
- `test_no_warning_on_non_glob_pattern` — confirms no warning for literal (non-glob) required files.
- `test_symlinks_excluded_from_glob` — creates a real file plus a stale symlink, verifies the symlink is excluded and the single real file matches cleanly.

## Testing

- All 698 tests pass (`pytest tests/ --ignore=tests/utils/test_turtle_canvas.py -q`).
- 100% coverage on `file_set_up.py`.
- Pre-commit hooks pass.