### PR TITLE
Fix misleading import failure hints by reporting missing dependency and source location

### DIFF
--- a/src/generic_grader/utils/importer.py
+++ b/src/generic_grader/utils/importer.py
@@ -104,7 +104,7 @@ class Importer:
                 if isinstance(current_e, ModuleNotFoundError):
                     missing_name = current_e.name or missing_name
 
-            if missing_name == module:
+            if missing_name == module or module.startswith(missing_name + "."):
                 hint = (
                     f"Make sure you have submitted a module named `{module}` and "
                     f"it contains the definition of `{obj_name}`."

--- a/src/generic_grader/utils/importer.py
+++ b/src/generic_grader/utils/importer.py
@@ -68,14 +68,37 @@ class Importer:
                 )
             )
             test.failureException = cls.InputError
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as e:
+            # Handle exception due to absent target module, reporting deepest error in chain.
+            missing_name = e.name or module
+            current_e = e
+            while True:
+                next_e = current_e.__cause__ or current_e.__context__
+                if next_e is None:
+                    break
+                current_e = next_e
+                if isinstance(current_e, ModuleNotFoundError):
+                    missing_name = current_e.name or missing_name
+
+            if missing_name == module:
+                hint = (
+                    f"Make sure you have submitted a file named `{module}.py` and "
+                    f"it contains the definition of `{obj_name}`."
+                )
+            else:
+                hint = (
+                    f"Your `{module}` module imports `{missing_name}`, but "
+                    f"that module could not be found. `{missing_name}` may be "
+                    f"imported directly by `{module}`, or by another module that "
+                    f"`{module}` depends on. If it is your own module, include "
+                    "the required file in your submission."
+                )
+
             test.failureException = ModuleNotFoundError
             fail_msg = (
                 cls.wrapper.fill(f"Unable to import `{module}`.")
                 + "\n\nHint:\n"
-                + cls.wrapper.fill(
-                    f"Make sure you have submitted a file named `{module}.py and it contains the definition of `{obj_name}`."
-                )
+                + cls.wrapper.fill(hint)
             )
         except Exception as e:
             fail_msg = handle_error(e, f"Error while importing `{obj_name}`.")

--- a/src/generic_grader/utils/importer.py
+++ b/src/generic_grader/utils/importer.py
@@ -1,6 +1,8 @@
 """Handle importing objects from student code."""
 
+import traceback
 import unittest
+from pathlib import Path
 
 from attrs import evolve
 
@@ -22,6 +24,28 @@ class Importer:
     def raise_input_error(cls, *args, **kwargs):
         """Raise our custom exception."""
         raise cls.InputError()
+
+    @classmethod
+    def _import_location_hint(cls, e: BaseException):
+        """Return a concise location hint for a failed import from traceback."""
+        tb = traceback.extract_tb(e.__traceback__)
+        if not tb:
+            return None
+
+        frame = tb[-1]
+        for candidate in reversed(tb):
+            if candidate.line and "import" in candidate.line:
+                frame = candidate
+                break
+
+        line = (frame.line or "").strip()
+        filename = Path(frame.filename).name
+        if line:
+            return (
+                f"The error occurred in `{filename}` on line {frame.lineno}: "
+                f"`{line}`."
+            )
+        return f"The error occurred in `{filename}` on line {frame.lineno}."
 
     @classmethod
     def import_obj(cls, test: unittest.TestCase, module: str, o: Options):
@@ -71,7 +95,7 @@ class Importer:
         except ModuleNotFoundError as e:
             # Handle exception due to absent target module, reporting deepest error in chain.
             missing_name = e.name or module
-            current_e = e
+            current_e: BaseException = e
             while True:
                 next_e = current_e.__cause__ or current_e.__context__
                 if next_e is None:
@@ -82,7 +106,7 @@ class Importer:
 
             if missing_name == module:
                 hint = (
-                    f"Make sure you have submitted a file named `{module}.py` and "
+                    f"Make sure you have submitted a module named `{module}` and "
                     f"it contains the definition of `{obj_name}`."
                 )
             else:
@@ -90,9 +114,14 @@ class Importer:
                     f"Your `{module}` module imports `{missing_name}`, but "
                     f"that module could not be found. `{missing_name}` may be "
                     f"imported directly by `{module}`, or by another module that "
-                    f"`{module}` depends on. If it is your own module, include "
-                    "the required file in your submission."
+                    f"`{module}` depends on. If it is your own module, make sure "
+                    "that it is included in your submission. If it is not your own "
+                    "module, that dependency may not be available in the autograder "
+                    "environment."
                 )
+                location_hint = cls._import_location_hint(current_e)
+                if location_hint:
+                    hint += f" {location_hint}"
 
             test.failureException = ModuleNotFoundError
             fail_msg = (

--- a/tests/utils/test_importer.py
+++ b/tests/utils/test_importer.py
@@ -172,6 +172,19 @@ missing_dependency_cases = [
             "in `fake_dependency.py` on line 2:",
         ],
     },
+    {
+        # Tests dotted module import where the parent package is missing.
+        # Python raises ModuleNotFoundError(name='fake_pkg'), not name='fake_pkg.submod',
+        # so the prefix check is required to avoid a misleading dependency hint.
+        "module": "fake_pkg.submod",
+        "object": "fake_obj",
+        "files": {},
+        "expected_messages": [
+            "Unable to import `fake_pkg.submod`.",
+            "Make sure you have submitted a module named `fake_pkg.submod`",
+            "contains the definition of `fake_obj`.",
+        ],
+    },
 ]
 
 

--- a/tests/utils/test_importer.py
+++ b/tests/utils/test_importer.py
@@ -80,7 +80,7 @@ error_cases = [
         # Tests the except block on line 65
         "module": "fake_module",
         "error": ModuleNotFoundError,
-        "message": "\n  Unable to import `fake_module`.\n\nHint:\n  Make sure you have submitted a file named `fake_module.py and it\n  contains the definition of `fake_obj`.",
+        "message": "\n  Unable to import `fake_module`.\n\nHint:\n  Make sure you have submitted a file named `fake_module.py` and it\n  contains the definition of `fake_obj`.",
         "object": "fake_obj",
     },
     {  # Test quit_error
@@ -133,3 +133,21 @@ def test_error_message(fix_syspath, case):
     with pytest.raises(Exception) as exc_info:
         Importer.import_obj(test, case["module"], Options(obj_name=case["object"]))
     assert case["message"] in str(exc_info.value)
+
+
+def test_nested_missing_dependency_message(fix_syspath):
+    """Importer should report the inner missing dependency for nested imports."""
+    fake_file = fix_syspath / "fake_module.py"
+    # Write import statement for non-existent inner module
+    fake_file.write_text(
+        "import fake_inner_module.fake_inner_obj\nfake_obj = lambda: None"
+    )
+
+    test = FakeTest()
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        Importer.import_obj(test, "fake_module", Options(obj_name="fake_obj"))
+
+    # Ensure traceback is correct
+    message = str(exc_info.value)
+    assert "Unable to import `fake_module`." in message
+    assert "imports `fake_inner_module`" in message

--- a/tests/utils/test_importer.py
+++ b/tests/utils/test_importer.py
@@ -76,13 +76,6 @@ error_cases = [
         "message": "Stuck at call to `input()` while importing `fake_func`",
         "object": "fake_func",
     },
-    {
-        # Tests the except block on line 65
-        "module": "fake_module",
-        "error": ModuleNotFoundError,
-        "message": "\n  Unable to import `fake_module`.\n\nHint:\n  Make sure you have submitted a file named `fake_module.py` and it\n  contains the definition of `fake_obj`.",
-        "object": "fake_obj",
-    },
     {  # Test quit_error
         "module": "fake_module",
         "error": QuitError,
@@ -113,9 +106,8 @@ error_cases = [
 def test_error_exception(fix_syspath, case):
     """Test the Importer's ability to raise the correct exception."""
 
-    if case["error"] is not ModuleNotFoundError:
-        fake_file = fix_syspath / (case["module"] + ".py")
-        fake_file.write_text(case["text"])
+    fake_file = fix_syspath / (case["module"] + ".py")
+    fake_file.write_text(case["text"])
 
     test = FakeTest()
     with pytest.raises(case["error"]):
@@ -125,9 +117,8 @@ def test_error_exception(fix_syspath, case):
 @pytest.mark.parametrize("case", error_cases)
 def test_error_message(fix_syspath, case):
     """Test the Importer's ability to provide helpful error messages."""
-    if case["error"] is not ModuleNotFoundError:
-        fake_file = fix_syspath / (case["module"] + ".py")
-        fake_file.write_text(case["text"])
+    fake_file = fix_syspath / (case["module"] + ".py")
+    fake_file.write_text(case["text"])
     test = FakeTest()
     #  Since we already check Exception type, we can use a generic Exception here
     with pytest.raises(Exception) as exc_info:
@@ -135,19 +126,65 @@ def test_error_message(fix_syspath, case):
     assert case["message"] in str(exc_info.value)
 
 
-def test_nested_missing_dependency_message(fix_syspath):
-    """Importer should report the inner missing dependency for nested imports."""
-    fake_file = fix_syspath / "fake_module.py"
-    # Write import statement for non-existent inner module
-    fake_file.write_text(
-        "import fake_inner_module.fake_inner_obj\nfake_obj = lambda: None"
-    )
+missing_dependency_cases = [
+    {
+        # Tests missing top-level module import.
+        "module": "fake_module",
+        "object": "fake_obj",
+        "files": {},
+        "expected_messages": [
+            "Unable to import `fake_module`.",
+            "Make sure you have submitted a module named `fake_module`",
+            "contains the definition of `fake_obj`.",
+        ],
+    },
+    {
+        # Tests nested missing dependency through another imported file.
+        "module": "fake_module",
+        "object": "fake_obj",
+        "files": {
+            "fake_module.py": "import fake_dependency\nfake_obj = lambda: None",
+            "fake_dependency.py": "import fake_inner_module\nhelper = 1",
+        },
+        "expected_messages": [
+            "Unable to import `fake_module`.",
+            "imports `fake_inner_module`",
+            "could not be found.",
+            "in `fake_dependency.py` on line 1:",
+        ],
+    },
+    {
+        # Tests missing dependency wrapped in another ModuleNotFoundError.
+        "module": "fake_module",
+        "object": "fake_obj",
+        "files": {
+            "fake_module.py": "import fake_dependency\nfake_obj = lambda: None",
+            "fake_dependency.py": (
+                "try:\n"
+                "    import fake_inner_module\n"
+                "except ModuleNotFoundError as err:\n"
+                "    raise ModuleNotFoundError(name='fake_dependency_proxy') from err\n"
+            ),
+        },
+        "expected_messages": [
+            "Unable to import `fake_module`.",
+            "imports `fake_inner_module`",
+            "in `fake_dependency.py` on line 2:",
+        ],
+    },
+]
+
+
+@pytest.mark.parametrize("case", missing_dependency_cases)
+def test_nested_missing_dependency_message(fix_syspath, case):
+    """Importer should report clear messages for missing dependencies."""
+    for file_name, file_text in case["files"].items():
+        fake_file = fix_syspath / file_name
+        fake_file.write_text(file_text)
 
     test = FakeTest()
     with pytest.raises(ModuleNotFoundError) as exc_info:
-        Importer.import_obj(test, "fake_module", Options(obj_name="fake_obj"))
+        Importer.import_obj(test, case["module"], Options(obj_name=case["object"]))
 
-    # Ensure traceback is correct
-    message = str(exc_info.value)
-    assert "Unable to import `fake_module`." in message
-    assert "imports `fake_inner_module`" in message
+    for expected_message in case["expected_messages"]:
+        assert expected_message in str(exc_info.value)


### PR DESCRIPTION
### Summary
Resolves issue #81 by improving how import failures are reported in the importer utility.  
Instead of assuming the submitted module is missing, the error handling now identifies the deepest missing dependency and reports where the failing import occurred.

### Changes
#### `src/generic_grader/utils/importer.py`
1. Traverse `ModuleNotFoundError` cause/context chain to find the deepest missing module name.
2. Keep the direct missing-module hint for cases where the submitted module itself is not found.
3. For nested dependency failures, provide a clearer hint that explains the missing dependency could be user-owned or unavailable in the grading environment.
4. Extract traceback location details for the failure site and report filename and line number.

#### `tests/utils/test_importer.py`
1. Added coverage for nested missing dependency cases.
2. Added a wrapped `ModuleNotFoundError` case to ensure deepest dependency extraction remains correct.

### Testing
- All 702 tests pass.
- 97% coverage on `importer.py`, two defensive/fallback paths would require mocked traceback objects to trigger.