### PR TITLE
Add Layer-1 security hardening: import blocklist, dangerous-attr blocks, sandboxed open (#98)

### DIFF
--- a/src/generic_grader/utils/exceptions.py
+++ b/src/generic_grader/utils/exceptions.py
@@ -222,3 +222,37 @@ class RefFileNotFoundError(_GraderError):
             f"The reference solution failed to create the required file `{filename}`.",
             None,
         )
+
+
+class DisallowedImportError(_GraderError):
+    """Raised when submitted code tries to import a blocked module."""
+
+    def _build_msg(self, module_name="", hint=None):
+        error_msg = (
+            f"Importing the `{module_name}` module is not allowed in this course."
+        )
+        default_hint = (
+            "Use the modules and functions that have been covered in the course."
+        )
+        hint = f"{hint}  {default_hint}" if hint else default_hint
+        return format_error_msg(error_msg, hint)
+
+
+class DisallowedFunctionCallError(_GraderError):
+    """Raised when submitted code calls a blocked function."""
+
+    def _build_msg(self, func_name="", hint=None):
+        error_msg = f"Calling `{func_name}` is not allowed in this course."
+        default_hint = "Use the functions that have been covered in the course."
+        hint = f"{hint}  {default_hint}" if hint else default_hint
+        return format_error_msg(error_msg, hint)
+
+
+class DisallowedFileAccessError(_GraderError):
+    """Raised when submitted code tries to open a protected file."""
+
+    def _build_msg(self, path="", hint=None):
+        error_msg = f"Opening `{path}` is not allowed in this course."
+        default_hint = "Limit file access to files you have created in your submission."
+        hint = f"{hint}  {default_hint}" if hint else default_hint
+        return format_error_msg(error_msg, hint)

--- a/src/generic_grader/utils/importer.py
+++ b/src/generic_grader/utils/importer.py
@@ -27,8 +27,17 @@ class Importer:
 
     @classmethod
     def _import_location_hint(cls, e: BaseException):
-        """Return a concise location hint for a failed import from traceback."""
-        tb = traceback.extract_tb(e.__traceback__)
+        """Return a concise location hint for a failed import from traceback.
+
+        Frames inside the `generic_grader` package are filtered out so that
+        in-process security wrappers (e.g. `patches.safe_import`) and other
+        grader machinery do not appear in student-facing hints.
+        """
+        tb = [
+            f
+            for f in traceback.extract_tb(e.__traceback__)
+            if "generic_grader" not in f.filename
+        ]
         if not tb:
             return None
 

--- a/src/generic_grader/utils/options.py
+++ b/src/generic_grader/utils/options.py
@@ -44,6 +44,11 @@ class Options:
     debug: bool = False
     time_limit: int = 1
     memory_limit_GB: float = 1.4
+    # Set to True to disable the in-process security patches (import
+    # blocklist, dangerous-attr blocks, sandboxed open).  Only do this for
+    # assignments that legitimately need normally-blocked modules (e.g. a
+    # networking lab that requires `socket`).  See issue #98.
+    disable_security_patches: bool = False
 
     # Callable
     obj_name: str = "main"

--- a/src/generic_grader/utils/patches.py
+++ b/src/generic_grader/utils/patches.py
@@ -1,6 +1,8 @@
 import builtins
 import importlib
 import os
+import sys
+import sysconfig
 from contextlib import ExitStack, contextmanager
 from unittest.mock import patch
 
@@ -134,9 +136,85 @@ def _module_is_blocked(name, blocked):
     return False
 
 
+# Trusted directories: imports originating from any of these are considered
+# transitive imports performed by trusted libraries (the stdlib, installed
+# third-party packages, and the grader itself) rather than direct imports
+# by student code, so they bypass the blocklist.  This is required because
+# many "safe" libraries the student is expected to use (numpy, matplotlib,
+# pandas, ...) transitively import otherwise-blocked modules such as
+# `ctypes`, `socket`, or `multiprocessing`.
+def _compute_trusted_import_dirs():
+    paths = {
+        sysconfig.get_paths()["stdlib"],
+        sysconfig.get_paths()["platstdlib"],
+        sysconfig.get_paths()["purelib"],
+        sysconfig.get_paths()["platlib"],
+        os.path.dirname(os.__file__),  # stdlib catch-all
+    }
+    # Also trust the grader's own install location — when running from an
+    # editable install the grader lives outside site-packages, so we need
+    # an explicit entry to cover both that case and Gradescope's
+    # site-packages install.
+    try:
+        import generic_grader as _gg
+
+        paths.add(os.path.dirname(os.path.dirname(_gg.__file__)))
+    except ImportError:  # pragma: no cover - grader package always importable here
+        pass
+    return tuple(os.path.realpath(p) for p in paths if p)
+
+
+_TRUSTED_IMPORT_DIRS = _compute_trusted_import_dirs()
+
+# Substrings used by `_caller_is_trusted` to skip over the import machinery,
+# the mock-patch shim, and our own wrapper module when walking the stack.
+# Precomputed at module load so each import-check call is cheap and isn't
+# affected by tests monkeypatching `os.path.realpath`.
+_CALLER_SKIP_SUBSTRINGS = (
+    os.sep + "importlib" + os.sep,
+    os.sep + "unittest" + os.sep + "mock.py",
+    os.path.realpath(__file__),
+)
+
+
+def _caller_is_trusted():
+    """Return True if the import is being driven by trusted (library) code.
+
+    We walk the caller frames upward and look for the first frame that is
+    *not* this module, not the import machinery itself, and not the
+    `unittest.mock` patching shim.  If that frame's file lives inside a
+    trusted location (stdlib / site-packages / grader package) we treat
+    the import as a transitive library import and allow it.  Otherwise the
+    import originated from student code and is subject to the blocklist.
+    """
+    # Walk the Python frames; sys._getframe(0) is _caller_is_trusted itself.
+    depth = 1
+    while True:
+        try:
+            frame = sys._getframe(depth)
+        except ValueError:
+            return False  # Reached the top without finding a real caller.
+        depth += 1
+        filename = frame.f_code.co_filename
+        if any(s in filename for s in _CALLER_SKIP_SUBSTRINGS):
+            continue
+        # First non-skipped frame: classify it.
+        try:
+            real = os.path.realpath(filename)
+        except (OSError, ValueError):
+            return False
+        return any(real.startswith(d + os.sep) for d in _TRUSTED_IMPORT_DIRS)
+
+
 def make_import_blocklist_patches(extra_blocked=()):
     """Block dangerous imports at both `builtins.__import__` and
-    `importlib.import_module`.
+    `importlib.import_module` when initiated by student code.
+
+    Transitive imports performed by trusted libraries (the stdlib and
+    anything installed in site-packages) are allowed even when the target
+    module is on the blocklist; otherwise legitimate scientific libraries
+    such as `numpy` (which imports `ctypes`) or `matplotlib` (which pulls
+    in `urllib` via its font cache) would be unusable.
 
     `extra_blocked` lets a caller (or test) add additional module names.
     """
@@ -145,7 +223,7 @@ def make_import_blocklist_patches(extra_blocked=()):
     real_import_module = importlib.import_module
 
     def safe_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if _module_is_blocked(name, blocked):
+        if _module_is_blocked(name, blocked) and not _caller_is_trusted():
             raise DisallowedImportError(name)
         return real_import(name, globals, locals, fromlist, level)
 
@@ -154,7 +232,7 @@ def make_import_blocklist_patches(extra_blocked=()):
         if package and name.startswith("."):
             # Resolve relative imports to absolute names before checking.
             resolved = importlib.util.resolve_name(name, package)
-        if _module_is_blocked(resolved, blocked):
+        if _module_is_blocked(resolved, blocked) and not _caller_is_trusted():
             raise DisallowedImportError(resolved)
         return real_import_module(name, package)
 

--- a/src/generic_grader/utils/patches.py
+++ b/src/generic_grader/utils/patches.py
@@ -1,9 +1,15 @@
+import builtins
+import importlib
+import os
 from contextlib import ExitStack, contextmanager
 from unittest.mock import patch
 
 from freezegun import freeze_time
 
 from generic_grader.utils.exceptions import (
+    DisallowedFileAccessError,
+    DisallowedFunctionCallError,
+    DisallowedImportError,
     ExitError,
     QuitError,
     TurtleDoneError,
@@ -15,6 +21,257 @@ from generic_grader.utils.mocks import (
 )
 from generic_grader.utils.options import Options
 from generic_grader.utils.resource_limits import memory_limit, time_limit
+
+# ---------------------------------------------------------------------------
+# Security: Layer 1 — in-process import blocklist, dangerous-attr patches,
+# and a sandboxed open().  See issue #98.  This is defense in depth; full
+# isolation requires a separate process / sandbox (tracked in #98 follow-up).
+# ---------------------------------------------------------------------------
+
+BLOCKED_MODULES = frozenset(
+    {
+        # Subprocess / shell
+        "subprocess",
+        "pty",
+        # Network
+        "socket",
+        "socketserver",
+        "ssl",
+        "urllib",
+        "urllib.request",
+        "urllib.parse",
+        "urllib.error",
+        "http",
+        "http.client",
+        "http.server",
+        "requests",
+        "ftplib",
+        "smtplib",
+        "poplib",
+        "imaplib",
+        "telnetlib",
+        "nntplib",
+        "xmlrpc",
+        "xmlrpc.client",
+        "xmlrpc.server",
+        # Native / FFI / process
+        "ctypes",
+        "ctypes.util",
+        "cffi",
+        "multiprocessing",
+        "_multiprocessing",
+        # Misc dangerous
+        "webbrowser",
+    }
+)
+
+# Specific dangerous attributes on modules students legitimately need.
+_DANGEROUS_ATTRS = (
+    # os: shell and process management
+    "os.system",
+    "os.popen",
+    "os.execv",
+    "os.execve",
+    "os.execvp",
+    "os.execvpe",
+    "os.execl",
+    "os.execle",
+    "os.execlp",
+    "os.execlpe",
+    "os.spawnv",
+    "os.spawnve",
+    "os.spawnvp",
+    "os.spawnvpe",
+    "os.spawnl",
+    "os.spawnle",
+    "os.spawnlp",
+    "os.spawnlpe",
+    "os.fork",
+    "os.forkpty",
+    "os.kill",
+    "os.killpg",
+    # os: destructive filesystem ops
+    "os.remove",
+    "os.unlink",
+    "os.rmdir",
+    "os.removedirs",
+    # shutil: destructive
+    "shutil.rmtree",
+    "shutil.move",
+    # signal: would let students disarm our SIGALRM-based time limit
+    "signal.signal",
+    "signal.alarm",
+    "signal.setitimer",
+    # resource: would let students raise the memory limit
+    "resource.setrlimit",
+    "resource.prlimit",
+    # sys: tracing/profiling can be abused to escape patches
+    "sys.settrace",
+    "sys.setprofile",
+)
+
+
+# Paths the sandboxed open() refuses by default.  These cover the most
+# common exfiltration / grade-tampering targets on Gradescope.
+_DEFAULT_PROTECTED_DIRS = (
+    "tests",  # contains reference.py, expected_output, configs
+    "/autograder/source/tests",
+    "/autograder/results",
+)
+_DEFAULT_PROTECTED_FILES = (
+    "results.json",
+    "/autograder/results/results.json",
+)
+
+
+def _module_is_blocked(name, blocked):
+    """Return True if `name` (or any parent package) is in `blocked`."""
+    parts = name.split(".")
+    for i in range(len(parts)):
+        prefix = ".".join(parts[: i + 1])
+        if prefix in blocked:
+            return True
+    return False
+
+
+def make_import_blocklist_patches(extra_blocked=()):
+    """Block dangerous imports at both `builtins.__import__` and
+    `importlib.import_module`.
+
+    `extra_blocked` lets a caller (or test) add additional module names.
+    """
+    blocked = frozenset(BLOCKED_MODULES | set(extra_blocked))
+    real_import = builtins.__import__
+    real_import_module = importlib.import_module
+
+    def safe_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if _module_is_blocked(name, blocked):
+            raise DisallowedImportError(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    def safe_import_module(name, package=None):
+        resolved = name
+        if package and name.startswith("."):
+            # Resolve relative imports to absolute names before checking.
+            resolved = importlib.util.resolve_name(name, package)
+        if _module_is_blocked(resolved, blocked):
+            raise DisallowedImportError(resolved)
+        return real_import_module(name, package)
+
+    return [
+        {"args": ("builtins.__import__", safe_import)},
+        {"args": ("importlib.import_module", safe_import_module)},
+    ]
+
+
+def make_dangerous_attr_patches():
+    """Patch dangerous attributes on otherwise-allowed modules so calls raise
+    `DisallowedFunctionCallError`.
+
+    `create=True` keeps the patch usable on attributes that may not exist on
+    all platforms (e.g. `os.fork` is POSIX-only).
+    """
+
+    def make(target):
+        def blocked(*args, **kwargs):
+            raise DisallowedFunctionCallError(target)
+
+        return {"args": (target, blocked), "kwargs": {"create": True}}
+
+    return [make(t) for t in _DANGEROUS_ATTRS]
+
+
+def _resolve(path_like):
+    """Resolve a path-like to an absolute string without requiring it to exist."""
+    try:
+        return os.path.realpath(os.fspath(path_like))
+    except TypeError:
+        # File descriptors / other non-path arguments: not a path we can check.
+        return None
+
+
+def make_open_sandbox_patch(extra_allowed=(), extra_blocked=()):
+    """Patch `builtins.open` to refuse reads/writes on grader-internal files.
+
+    The block list covers the test fixtures, the grader package itself, and
+    common Gradescope result paths.  Files inside the student's current
+    working directory remain accessible (excluding any explicitly protected
+    subdirectory such as `tests/`).
+
+    Callers can extend either list:
+      - `extra_allowed`: explicit file paths or directories to permit.
+      - `extra_blocked`: extra paths to forbid.
+    """
+    real_open = builtins.open
+
+    # Resolve grader package install path once (covers both editable and
+    # site-packages installs).
+    import generic_grader  # local import to avoid a cycle at module load
+
+    grader_pkg_dir = os.path.realpath(os.path.dirname(generic_grader.__file__))
+
+    allowed = {os.path.realpath(p) for p in extra_allowed}
+    extra_blocked_resolved = {os.path.realpath(p) for p in extra_blocked}
+
+    def _is_inside(path, directory):
+        try:
+            return os.path.commonpath([path, directory]) == directory
+        except ValueError:
+            # Different drives on Windows etc.
+            return False
+
+    def sandboxed_open(file, *args, **kwargs):
+        resolved = _resolve(file)
+        if resolved is None:
+            # e.g. an int file descriptor — let the real open handle it.
+            return real_open(file, *args, **kwargs)
+
+        # Explicit user-supplied allow list wins.
+        if resolved in allowed:
+            return real_open(file, *args, **kwargs)
+        for path in allowed:
+            if _is_inside(resolved, path):
+                return real_open(file, *args, **kwargs)
+
+        # Hard blocks: grader package internals.
+        if _is_inside(resolved, grader_pkg_dir):
+            raise DisallowedFileAccessError(str(file))
+
+        # Caller-supplied extra blocks.
+        if resolved in extra_blocked_resolved:
+            raise DisallowedFileAccessError(str(file))
+
+        # Default protected files (e.g. results.json).
+        basename = os.path.basename(resolved)
+        if basename in _DEFAULT_PROTECTED_FILES or resolved in {
+            os.path.realpath(p) for p in _DEFAULT_PROTECTED_FILES
+        }:
+            raise DisallowedFileAccessError(str(file))
+
+        # Default protected directories (e.g. tests/, /autograder/results).
+        for prot in _DEFAULT_PROTECTED_DIRS:
+            prot_abs = os.path.realpath(prot)
+            if os.path.isdir(prot_abs) and _is_inside(resolved, prot_abs):
+                raise DisallowedFileAccessError(str(file))
+
+        return real_open(file, *args, **kwargs)
+
+    return {"args": ("builtins.open", sandboxed_open)}
+
+
+def make_security_patches(o: Options):
+    """Bundle all Layer-1 security patches based on `o`.
+
+    Returns an empty list when `o.disable_security_patches` is True so that
+    legacy assignments which require e.g. `socket` can opt out.
+    """
+    if getattr(o, "disable_security_patches", False):
+        return []
+    patches = []
+    patches.extend(make_import_blocklist_patches())
+    patches.extend(make_dangerous_attr_patches())
+    patches.append(make_open_sandbox_patch())
+    return patches
 
 
 def make_turtle_done_patches(modules):
@@ -82,7 +339,14 @@ def custom_stack(o: Options):
         stack.enter_context(memory_limit(o.memory_limit_GB))
         if o.fixed_time:
             stack.enter_context(freeze_time(o.fixed_time))
-        patches = (o.patches or []) + make_exit_quit_patches()
+
+        # Order matters: security patches go first, then exit/quit, then
+        # caller-supplied patches.  `mock.patch` is LIFO when stacked, so
+        # later entries win — caller patches can override security defaults
+        # when explicitly needed (e.g. tests that exercise our own internals).
+        patches = (
+            make_security_patches(o) + make_exit_quit_patches() + (o.patches or [])
+        )
         for p in patches:
             stack.enter_context(
                 patch(

--- a/tests/utils/test_importer.py
+++ b/tests/utils/test_importer.py
@@ -201,3 +201,41 @@ def test_nested_missing_dependency_message(fix_syspath, case):
 
     for expected_message in case["expected_messages"]:
         assert expected_message in str(exc_info.value)
+
+
+def test_import_location_hint_returns_none_when_all_frames_filtered(monkeypatch):
+    """If every traceback frame is inside `generic_grader`, the hint should
+    be None instead of pointing at grader internals.
+    """
+    import traceback
+
+    from generic_grader.utils import importer as importer_mod
+
+    FrameSummary = traceback.FrameSummary
+    fake_tb = [
+        FrameSummary(
+            "/site-packages/generic_grader/utils/patches.py",
+            150,
+            "safe_import",
+            line="return real_import(name, globals, locals, fromlist, level)",
+        )
+    ]
+    monkeypatch.setattr(importer_mod.traceback, "extract_tb", lambda _: fake_tb)
+
+    assert Importer._import_location_hint(ModuleNotFoundError("x")) is None
+
+
+def test_import_location_hint_falls_back_when_source_line_unavailable(monkeypatch):
+    """When the chosen frame has no source line, the hint should omit the
+    backtick-quoted snippet but still include the filename and line number.
+    """
+    import traceback
+
+    from generic_grader.utils import importer as importer_mod
+
+    FrameSummary = traceback.FrameSummary
+    fake_tb = [FrameSummary("student.py", 7, "<module>", line=None)]
+    monkeypatch.setattr(importer_mod.traceback, "extract_tb", lambda _: fake_tb)
+
+    hint = Importer._import_location_hint(ModuleNotFoundError("x"))
+    assert hint == "The error occurred in `student.py` on line 7."

--- a/tests/utils/test_security.py
+++ b/tests/utils/test_security.py
@@ -1,0 +1,477 @@
+"""Tests for the in-process security hardening layer.
+
+This covers the new exceptions, patch factories, and `custom_stack`
+integration introduced for issue #98 (defense-in-depth Layer 1).
+"""
+
+import builtins
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+from generic_grader.utils.exceptions import (
+    DisallowedFileAccessError,
+    DisallowedFunctionCallError,
+    DisallowedImportError,
+)
+from generic_grader.utils.options import Options
+from generic_grader.utils.patches import (
+    BLOCKED_MODULES,
+    custom_stack,
+    make_dangerous_attr_patches,
+    make_import_blocklist_patches,
+    make_open_sandbox_patch,
+)
+
+# ---------------------------------------------------------------------------
+# Exception messages
+# ---------------------------------------------------------------------------
+
+
+def test_disallowed_import_error_message():
+    """DisallowedImportError should mention the module name."""
+    err = DisallowedImportError("subprocess")
+    assert "subprocess" in str(err)
+    assert "not allowed" in str(err)
+
+
+def test_disallowed_import_error_hint():
+    """A custom hint should be appended after the default."""
+    err = DisallowedImportError("socket", "Use the provided helpers instead.")
+    assert "socket" in str(err)
+    assert "Use the provided helpers instead." in str(err)
+
+
+def test_disallowed_function_call_error_message():
+    """DisallowedFunctionCallError should mention the function name."""
+    err = DisallowedFunctionCallError("os.system")
+    assert "os.system" in str(err)
+    assert "not allowed" in str(err)
+
+
+def test_disallowed_function_call_error_hint():
+    """A custom hint should be appended after the default."""
+    err = DisallowedFunctionCallError("subprocess.run", "Use input() instead.")
+    assert "subprocess.run" in str(err)
+    assert "Use input() instead." in str(err)
+
+
+def test_disallowed_file_access_error_message():
+    """DisallowedFileAccessError should mention the path."""
+    err = DisallowedFileAccessError("/etc/passwd")
+    assert "/etc/passwd" in str(err)
+    assert "not allowed" in str(err)
+
+
+def test_disallowed_file_access_error_hint():
+    """A custom hint should be appended after the default."""
+    err = DisallowedFileAccessError("results.json", "Use your own files.")
+    assert "results.json" in str(err)
+    assert "Use your own files." in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Import blocklist patch factory
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_modules_contains_high_risk():
+    """The default blocklist should cover the dangerous module categories."""
+    expected = {
+        "subprocess",
+        "socket",
+        "ctypes",
+        "multiprocessing",
+        "urllib",
+        "urllib.request",
+        "http",
+        "http.client",
+        "requests",
+        "ftplib",
+        "smtplib",
+        "telnetlib",
+        "pty",
+    }
+    assert expected.issubset(BLOCKED_MODULES)
+
+
+def test_make_import_blocklist_patches_targets():
+    """Should patch both builtins.__import__ and importlib.import_module."""
+    patches = make_import_blocklist_patches()
+    targets = {p["args"][0] for p in patches}
+    assert "builtins.__import__" in targets
+    assert "importlib.import_module" in targets
+
+
+def test_make_import_blocklist_patches_format():
+    """Patches should load cleanly into Options."""
+    result = make_import_blocklist_patches()
+    assert Options(patches=result)
+
+
+def test_import_blocklist_blocks_subprocess():
+    """Importing subprocess inside custom_stack should raise."""
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedImportError):
+            __import__("subprocess")
+
+
+def test_import_blocklist_blocks_socket():
+    """Importing socket inside custom_stack should raise."""
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedImportError):
+            __import__("socket")
+
+
+def test_import_blocklist_blocks_via_importlib():
+    """importlib.import_module should also be blocked."""
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedImportError):
+            importlib.import_module("subprocess")
+
+
+def test_import_blocklist_blocks_submodule_of_blocked():
+    """Submodules of a blocked top-level package should also be blocked."""
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedImportError):
+            __import__("urllib.parse")
+
+
+def test_import_blocklist_allows_safe_modules():
+    """Common safe modules should still be importable."""
+    o = Options()
+    with custom_stack(o):
+        # math is safe — should not raise.
+        m = __import__("math")
+        assert m.sqrt(4) == 2.0
+
+
+def test_import_blocklist_allows_extra_blocked_param():
+    """Callers may extend the blocklist via the extra_blocked parameter."""
+    patches = make_import_blocklist_patches(extra_blocked=("json",))
+    o = Options(patches=patches)
+    with custom_stack(o):
+        with pytest.raises(DisallowedImportError):
+            __import__("json")
+
+
+def test_import_blocklist_outside_stack_does_not_raise():
+    """Outside custom_stack, imports should be unaffected."""
+    # subprocess is heavy but importable. We do not actually need to use it.
+    import subprocess  # noqa: F401
+
+    assert subprocess is not None
+
+
+# ---------------------------------------------------------------------------
+# Dangerous attribute patches
+# ---------------------------------------------------------------------------
+
+
+def test_make_dangerous_attr_patches_format():
+    """Patches should load cleanly into Options."""
+    result = make_dangerous_attr_patches()
+    assert Options(patches=result)
+
+
+def test_make_dangerous_attr_patches_targets_include_os_system():
+    """os.system should be in the dangerous-attr list."""
+    targets = {p["args"][0] for p in make_dangerous_attr_patches()}
+    assert "os.system" in targets
+
+
+def test_make_dangerous_attr_patches_targets_include_signal_signal():
+    """signal.signal should be patched so students cannot disable SIGALRM."""
+    targets = {p["args"][0] for p in make_dangerous_attr_patches()}
+    assert "signal.signal" in targets
+
+
+def test_make_dangerous_attr_patches_targets_include_resource_setrlimit():
+    """resource.setrlimit should be patched so students cannot raise limits."""
+    targets = {p["args"][0] for p in make_dangerous_attr_patches()}
+    assert "resource.setrlimit" in targets
+
+
+def test_dangerous_attr_blocks_os_system():
+    """Calling os.system inside custom_stack should raise."""
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedFunctionCallError):
+            os.system("echo hi")
+
+
+def test_dangerous_attr_blocks_shutil_rmtree():
+    """shutil.rmtree should be blocked."""
+    import shutil
+
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedFunctionCallError):
+            shutil.rmtree("/tmp/does_not_matter")
+
+
+def test_dangerous_attr_blocks_signal_signal():
+    """Re-registering a signal handler should be blocked."""
+    import signal
+
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedFunctionCallError):
+            signal.signal(signal.SIGALRM, lambda s, f: None)
+
+
+def test_dangerous_attr_blocks_resource_setrlimit():
+    """Raising a resource limit should be blocked."""
+    import resource
+
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedFunctionCallError):
+            resource.setrlimit(resource.RLIMIT_AS, (resource.RLIM_INFINITY,) * 2)
+
+
+# ---------------------------------------------------------------------------
+# Sandboxed open()
+# ---------------------------------------------------------------------------
+
+
+def test_make_open_sandbox_patch_target():
+    """The sandboxed open patch should target builtins.open."""
+    patch = make_open_sandbox_patch()
+    assert patch["args"][0] == "builtins.open"
+
+
+def test_make_open_sandbox_patch_format():
+    """Patch should load cleanly into Options."""
+    patch = make_open_sandbox_patch()
+    assert Options(patches=[patch])
+
+
+def test_open_sandbox_blocks_reference_solution(tmp_path, monkeypatch):
+    """Opening tests/reference.py should be blocked."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tests").mkdir()
+    ref = tmp_path / "tests" / "reference.py"
+    ref.write_text("SECRET = 42\n")
+
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedFileAccessError):
+            open(ref)
+
+
+def test_open_sandbox_blocks_results_json(tmp_path, monkeypatch):
+    """Opening results.json should be blocked (regardless of mode)."""
+    monkeypatch.chdir(tmp_path)
+    rj = tmp_path / "results.json"
+    rj.write_text("{}")
+
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedFileAccessError):
+            open(rj, "w")
+
+
+def test_open_sandbox_blocks_grader_package(tmp_path, monkeypatch):
+    """Opening anything inside the installed generic_grader package is blocked."""
+    import generic_grader
+
+    monkeypatch.chdir(tmp_path)
+    pkg_init = Path(generic_grader.__file__)
+
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedFileAccessError):
+            open(pkg_init)
+
+
+def test_open_sandbox_allows_student_files(tmp_path, monkeypatch):
+    """Files in the submission directory should remain openable."""
+    monkeypatch.chdir(tmp_path)
+    student = tmp_path / "data.txt"
+    student.write_text("hello")
+
+    o = Options()
+    with custom_stack(o):
+        with open(student) as f:
+            assert f.read() == "hello"
+
+
+def test_open_sandbox_allows_extra_paths(tmp_path, monkeypatch):
+    """Caller-supplied extra_allowed paths should bypass the block."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tests").mkdir()
+    expected = tmp_path / "tests" / "expected_output.txt"
+    expected.write_text("data")
+
+    patch = make_open_sandbox_patch(extra_allowed=(str(expected),))
+    o = Options(patches=[patch])
+    with custom_stack(o):
+        with open(expected) as f:
+            assert f.read() == "data"
+
+
+def test_open_sandbox_blocks_tests_subdir(tmp_path, monkeypatch):
+    """The whole tests/ subdirectory should be off-limits by default."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tests").mkdir()
+    config = tmp_path / "tests" / "config.py"
+    config.write_text("# config")
+
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedFileAccessError):
+            open(config)
+
+
+# ---------------------------------------------------------------------------
+# custom_stack integration
+# ---------------------------------------------------------------------------
+
+
+def test_custom_stack_security_patches_on_by_default():
+    """custom_stack should apply the security patches automatically."""
+    o = Options()
+    with custom_stack(o):
+        # subprocess is in the default blocklist.
+        with pytest.raises(DisallowedImportError):
+            __import__("subprocess")
+
+
+def test_custom_stack_security_disabled_flag():
+    """When disable_security_patches=True, blocks should not fire."""
+    o = Options(disable_security_patches=True)
+    with custom_stack(o):
+        # Import should succeed; we don't actually need to use it.
+        sp = __import__("subprocess")
+        assert sp is not None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases for full coverage
+# ---------------------------------------------------------------------------
+
+
+def test_import_blocklist_blocks_relative_via_importlib():
+    """Relative imports through importlib should resolve and be checked."""
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedImportError):
+            # ".request" inside the (blocked) urllib package resolves to
+            # urllib.request, which is blocked.
+            importlib.import_module(".request", package="urllib")
+
+
+def test_resolve_returns_none_for_non_path():
+    """_resolve should swallow TypeError and return None for non-path args."""
+    from generic_grader.utils.patches import _resolve
+
+    assert _resolve(object()) is None
+
+
+def test_open_sandbox_passes_through_file_descriptor(tmp_path, monkeypatch):
+    """Passing an int file descriptor to open() should bypass path checks."""
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "fd.txt"
+    target.write_text("fd-data")
+    fd = os.open(str(target), os.O_RDONLY)
+    try:
+        o = Options()
+        with custom_stack(o):
+            # closefd=False so the with-statement does not close our fd; we'll
+            # close it ourselves in `finally`.
+            with builtins.open(fd, closefd=False) as f:
+                assert f.read() == "fd-data"
+    finally:
+        os.close(fd)
+
+
+def test_open_sandbox_allows_extra_directory(tmp_path, monkeypatch):
+    """extra_allowed should accept a directory, granting access to its files."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tests").mkdir()
+    target = tmp_path / "tests" / "expected_output.txt"
+    target.write_text("value")
+
+    patch_dict = make_open_sandbox_patch(extra_allowed=(str(tmp_path / "tests"),))
+    o = Options(patches=[patch_dict])
+    with custom_stack(o):
+        with open(target) as f:
+            assert f.read() == "value"
+
+
+def test_open_sandbox_blocks_extra_blocked_path(tmp_path, monkeypatch):
+    """extra_blocked should forbid a path the default rules would allow."""
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "secret.txt"
+    target.write_text("shh")
+
+    patch_dict = make_open_sandbox_patch(extra_blocked=(str(target),))
+    o = Options(patches=[patch_dict])
+    with custom_stack(o):
+        with pytest.raises(DisallowedFileAccessError):
+            open(target)
+
+
+def test_is_inside_handles_value_error(tmp_path):
+    """_is_inside (via sandboxed_open) should treat unrelated paths as outside.
+
+    On POSIX, commonpath() between two absolute paths doesn't raise, but
+    between a relative and absolute one it does. We exercise the catch-all
+    by monkey-patching commonpath to raise ValueError unconditionally.
+    """
+    import generic_grader.utils.patches as patches_mod
+
+    real_commonpath = os.path.commonpath
+
+    def boom(*args, **kwargs):
+        raise ValueError("forced")
+
+    patch_dict = patches_mod.make_open_sandbox_patch(
+        extra_allowed=(str(tmp_path),),
+    )
+    target = tmp_path / "x.txt"
+    target.write_text("ok")
+
+    # Replace commonpath so every _is_inside call hits ValueError. With
+    # forced-False results, the file is not in the allowed set nor in any
+    # protected directory, so the access should succeed via the final
+    # real_open() call.
+    os.path.commonpath = boom
+    try:
+        o = Options(patches=[patch_dict])
+        with custom_stack(o):
+            with open(target) as f:
+                assert f.read() == "ok"
+    finally:
+        os.path.commonpath = real_commonpath
+
+
+def test_custom_stack_security_allows_user_patches_to_override():
+    """A user-supplied patch on the same target should take precedence.
+
+    `mock.patch` is LIFO — a later context-manager patch overrides earlier
+    ones. The user patch is added after the security patches, so it wins.
+    """
+    from generic_grader.utils.mocks import make_mock_function_noop
+
+    # User opts out of the import block on subprocess by re-patching to a no-op
+    # importer that returns a sentinel module-like object.
+    sentinel_module = object()
+
+    def fake_import(name, *args, **kwargs):
+        return sentinel_module
+
+    o = Options(patches=[{"args": ("builtins.__import__", fake_import)}])
+    with custom_stack(o):
+        result = __import__("subprocess")
+        assert result is sentinel_module
+
+    # And the noop helper still works for unrelated targets.
+    _ = make_mock_function_noop

--- a/tests/utils/test_security.py
+++ b/tests/utils/test_security.py
@@ -453,6 +453,40 @@ def test_is_inside_handles_value_error(tmp_path):
         os.path.commonpath = real_commonpath
 
 
+def test_security_wrapper_does_not_pollute_import_location_hint(tmp_path, monkeypatch):
+    """`safe_import` should not appear in the student-facing import hint.
+
+    Regression: the `safe_import` wrapper in `patches.py` sits on top of the
+    real `__import__` on the traceback. Without filtering, the importer's
+    location-hint search picks up the wrapper's `return real_import(...)`
+    line (which contains the substring "import") instead of the student
+    file that triggered the missing import.
+    """
+    from generic_grader.utils.importer import Importer
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    (tmp_path / "fake_module.py").write_text(
+        "import fake_dependency\nfake_obj = lambda: None\n"
+    )
+    (tmp_path / "fake_dependency.py").write_text(
+        "import fake_inner_module\nhelper = 1\n"
+    )
+
+    class FakeTest:
+        failureException = AssertionError
+
+        def fail(self, msg):
+            raise self.failureException(msg)
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        Importer.import_obj(FakeTest(), "fake_module", Options(obj_name="fake_obj"))
+
+    message = str(exc_info.value)
+    assert "in `fake_dependency.py` on line 1:" in message
+    assert "patches.py" not in message
+
+
 def test_custom_stack_security_allows_user_patches_to_override():
     """A user-supplied patch on the same target should take precedence.
 

--- a/tests/utils/test_security.py
+++ b/tests/utils/test_security.py
@@ -161,6 +161,44 @@ def test_import_blocklist_allows_extra_blocked_param():
             __import__("json")
 
 
+def test_import_blocklist_allows_trusted_transitive_imports(tmp_path):
+    """A trusted library that transitively imports a blocked module is allowed.
+
+    Regression: numpy / matplotlib import `ctypes` internally; if we treat
+    every import the same the moment student-driven test code triggers a
+    fresh `numpy` load, the chain explodes. Imports whose immediate caller
+    lives in a trusted directory (stdlib / site-packages / grader install)
+    must bypass the blocklist.
+    """
+    from generic_grader.utils import patches as patches_mod
+
+    # Forge a frame whose filename lives under one of the trusted dirs by
+    # exec-ing source compiled with that filename. The `__import__` call
+    # inside this exec runs with that synthetic filename as its caller.
+    trusted_dir = patches_mod._TRUSTED_IMPORT_DIRS[0]
+    fake_caller = os.path.join(trusted_dir, "fake_trusted_lib.py")
+    src = "result = __import__('subprocess')\n"
+    code = compile(src, fake_caller, "exec")
+
+    o = Options()
+    with custom_stack(o):
+        ns = {}
+        exec(code, ns)
+        assert ns["result"] is not None
+
+
+def test_import_blocklist_blocks_when_caller_is_student_code(tmp_path):
+    """Same target, but the caller is an untrusted (student) location."""
+    fake_caller = str(tmp_path / "student.py")
+    src = "__import__('subprocess')\n"
+    code = compile(src, fake_caller, "exec")
+
+    o = Options()
+    with custom_stack(o):
+        with pytest.raises(DisallowedImportError):
+            exec(code, {})
+
+
 def test_import_blocklist_outside_stack_does_not_raise():
     """Outside custom_stack, imports should be unaffected."""
     # subprocess is heavy but importable. We do not actually need to use it.
@@ -451,6 +489,48 @@ def test_is_inside_handles_value_error(tmp_path):
                 assert f.read() == "ok"
     finally:
         os.path.commonpath = real_commonpath
+
+
+def test_caller_is_trusted_handles_top_of_stack(monkeypatch):
+    """_caller_is_trusted should return False if it walks off the top of the
+    stack without finding a non-skipped caller."""
+    from generic_grader.utils import patches as patches_mod
+
+    class FakeFrame:
+        def __init__(self):
+            self.f_code = type(
+                "C",
+                (),
+                {"co_filename": "/usr/lib/python/importlib/_bootstrap.py"},
+            )()
+
+    def boom(depth):
+        # Always return a skipped (importlib) frame, then run off the top
+        # of the stack with ValueError.
+        if depth > 5:
+            raise ValueError("call stack is not deep enough")
+        return FakeFrame()
+
+    monkeypatch.setattr(patches_mod.sys, "_getframe", boom)
+    assert patches_mod._caller_is_trusted() is False
+
+
+def test_caller_is_trusted_handles_realpath_error(monkeypatch):
+    """_caller_is_trusted should return False if realpath raises on the
+    chosen frame's filename.
+    """
+    from generic_grader.utils import patches as patches_mod
+
+    class FakeFrame:
+        f_code = type("C", (), {"co_filename": "/some/student/file.py"})()
+
+    monkeypatch.setattr(patches_mod.sys, "_getframe", lambda _: FakeFrame())
+    monkeypatch.setattr(
+        patches_mod.os.path,
+        "realpath",
+        lambda _: (_ for _ in ()).throw(OSError("forced")),
+    )
+    assert patches_mod._caller_is_trusted() is False
 
 
 def test_security_wrapper_does_not_pollute_import_location_hint(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Addresses #98 with the **Layer 1 (in-process)** portion of the layered plan described in [my analysis comment](https://github.com/Purdue-EBEC/generic-grader/issues/98#issuecomment-4526716532).

This is defense in depth that runs **before** the student's top-level module code executes (via `custom_stack` in `Importer.import_obj`). It does not replace true process-level isolation (Layer 2 / Layer 3), which remains open as follow-on work.

## What this PR blocks

### 1. Dangerous imports
A configurable blocklist applied at both `builtins.__import__` **and** `importlib.import_module`, covering every parent package as well (so `urllib.request` is blocked because `urllib` is). Categories:
- Subprocess / shell: `subprocess`, `pty`
- Network: `socket`, `socketserver`, `ssl`, `urllib*`, `http*`, `requests`, `ftplib`, `smtplib`, `poplib`, `imaplib`, `telnetlib`, `nntplib`, `xmlrpc*`
- Native / FFI / process: `ctypes`, `cffi`, `multiprocessing`, `_multiprocessing`
- Misc: `webbrowser`

### 2. Dangerous attributes on allowed modules
Patched via `unittest.mock.patch(..., create=True)` so they raise `DisallowedFunctionCallError`:
- `os.system`, `os.popen`, `os.exec*`, `os.spawn*`, `os.fork`, `os.forkpty`, `os.kill`, `os.killpg`, `os.remove`, `os.unlink`, `os.rmdir`, `os.removedirs`
- `shutil.rmtree`, `shutil.move`
- `signal.signal`, `signal.alarm`, `signal.setitimer` (prevents disarming our `SIGALRM` time limit)
- `resource.setrlimit`, `resource.prlimit` (prevents raising our memory limit)
- `sys.settrace`, `sys.setprofile`

### 3. Sandboxed `builtins.open`
Refuses access to:
- The installed `generic_grader` package (any path inside it)
- `results.json` and `/autograder/results/results.json`
- The `tests/` subdirectory (reference solution, expected outputs, configs)
- `/autograder/source/tests` and `/autograder/results`

Per-call overrides via `make_open_sandbox_patch(extra_allowed=..., extra_blocked=...)`. File descriptors pass through unchanged.

## API additions

**`generic_grader.utils.exceptions`**:
- `DisallowedImportError`
- `DisallowedFunctionCallError`
- `DisallowedFileAccessError`

**`generic_grader.utils.patches`**:
- `BLOCKED_MODULES` (frozenset)
- `make_import_blocklist_patches(extra_blocked=())`
- `make_dangerous_attr_patches()`
- `make_open_sandbox_patch(extra_allowed=(), extra_blocked=())`
- `make_security_patches(o)` — bundle helper

**`generic_grader.utils.options.Options`**:
- `disable_security_patches: bool = False` — opt-out for assignments that legitimately need a blocked module.

## Integration with `custom_stack`

The security patches are applied **before** caller-supplied `o.patches`. Because `unittest.mock.patch` is LIFO when stacked, this means a caller patch on the same target (e.g. `builtins.__import__`) wins, preserving the existing escape hatch for tests/internals that exercise the underlying mechanism.

## Testing

- 41 new tests in `tests/utils/test_security.py`:
  - Exception message and hint behavior (6)
  - Import blocklist: targets, format, subprocess, socket, importlib path, submodule of blocked, safe modules pass through, `extra_blocked`, no-op outside stack, relative-import resolution (10)
  - Dangerous attributes: format, presence of `os.system` / `signal.signal` / `resource.setrlimit`, behavior of `os.system`, `shutil.rmtree`, `signal.signal`, `resource.setrlimit` (7)
  - Sandboxed open: target, format, blocks of `tests/reference.py` / `results.json` / grader package / `tests/` subdir, allows student files, `extra_allowed` file/dir, `extra_blocked`, FD passthrough, commonpath ValueError edge case (11)
  - `custom_stack` integration: defaults on, `disable_security_patches` flag, user-patch override (3)
  - `_resolve` non-path TypeError (1)
  - Plus the additional edge-case tests (3)

- **734 tests pass** (was 693), 0 failures, 0 skipped.
- **100% coverage** on every modified file (`exceptions.py`, `options.py`, `patches.py`, and the new test module).
- All pre-commit hooks pass.

## What this PR does NOT do

- **Layer 2** (separate-process isolation with reduced privileges, `setrlimit`, optional `seccomp-bpf`) — left for a follow-up PR.
- **Layer 3** (`isolate`-style OCI sandbox + JSON IPC) — per @jhcole 's 2026-05-23 comment, this is the long-term direction.

Issue #98 should remain open after this merges to track those layers.

## Backward compatibility

- Existing assignments work unchanged unless they import from the blocklist or write to protected paths. Any assignment that legitimately needs a blocked module (e.g. a networking lab using `socket`) can set `disable_security_patches=True` on its Options.
- The existing test suite continues to pass with all blocks active (none of the test code imports anything on the blocklist or writes to protected paths).