### PR TITLE
Layer 3: sandbox isolation via `isolate` (issue #98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,26 @@ pip install generic-grader
 
    - on Windows, download the latest installers from https://github.com/UB-Mannheim/tesseract/wiki
 
-5. Install ghostscript
+5. Install [isolate](https://github.com/ioi/isolate) (used by the Layer-3
+   sandbox; the test suite skips one isolate-dependent smoke test when it
+   isn't present, but full coverage runs require it).  The GitHub Actions
+   workflow `.github/workflows/pytest.yml` will need a corresponding
+   maintainer-side update to add `isolate` to its `apt install` line.
+
+   - on Ubuntu 22.04+
+
+     ``` bash
+     sudo apt install isolate
+     ```
+
+   - other Linux distributions: build from source per the
+     [isolate README](https://github.com/ioi/isolate?tab=readme-ov-file#installation).
+
+   - macOS / Windows: isolate is Linux-only.  Run the sandbox tests in a
+     Linux VM or container.  The rest of the test suite still runs on the
+     host.
+
+6. Install ghostscript
 
    - on Linux
 
@@ -125,7 +144,7 @@ pip install generic-grader
 
    - on Windows, download the latest installers from https://ghostscript.com/releases/gsdnld.html
 
-6. Install the package.  Note that this installs the package as editable, so
+7. Install the package.  Note that this installs the package as editable, so
    edits will be automatically reflected in the installed package.
 
    ``` bash
@@ -137,22 +156,34 @@ pip install generic-grader
    uv sync --extra dev
    ```
 
-7. Install the pre-commit hooks.
+8. Install the pre-commit hooks.
 
    ``` bash
    pre-commit install
    ```
 
-8. Run the tests.
+9. Run the tests.
 
    ``` bash
    pytest
    ```
 
-9. Make changes ...
+10. Make changes ...
 
-10. Deactivate the virtual environment.
+11. Deactivate the virtual environment.
 
    ``` bash
    deactivate
    ```
+
+## Sandbox isolation (Layer 3)
+
+The grader can run a student's submission in a fresh, isolated
+subprocess per call rather than in-process.  Set
+`Options(use_sandbox=True)` to opt in.  Patches that need to cross
+the sandbox boundary must be expressed as `PatchSpec` instances
+(see `generic_grader.sandbox.patch_specs`).
+
+The sandbox uses [isolate](https://github.com/ioi/isolate); install
+it as part of the contributing setup above.  See [`ROADMAP.md`](ROADMAP.md)
+for the rollout plan.

--- a/README.md
+++ b/README.md
@@ -113,16 +113,57 @@ pip install generic-grader
    sandbox; the test suite skips one isolate-dependent smoke test when it
    isn't present, but full coverage runs require it).  The GitHub Actions
    workflow `.github/workflows/pytest.yml` will need a corresponding
-   maintainer-side update to add `isolate` to its `apt install` line.
+   maintainer-side update to install `isolate` (see the install steps below).
 
-   - on Ubuntu 22.04+
+   - on Ubuntu (24.04 tested) -- `isolate` isn't packaged in apt, so
+     build from source.  The full sequence, verified end-to-end:
 
      ``` bash
-     sudo apt install isolate
+     # Build dependencies.  asciidoc is needed for the manpages; if
+     # you'd rather skip the ~30 MB of asciidoc deps, you can build
+     # just the binary targets, but `make all` (which `make install`
+     # depends on) builds the manpages by default.
+     sudo apt install build-essential libcap-dev libseccomp-dev libsystemd-dev pkg-config asciidoc
+
+     # Clone and build.
+     git clone https://github.com/ioi/isolate.git
+     cd isolate
+     make all
+     sudo make install
+
+     # Create the unprivileged user isolate maps containerized
+     # processes into, and give it a subuid/subgid range.  On Ubuntu,
+     # `useradd --system` does NOT auto-populate /etc/sub{u,g}id, so
+     # the second command is required.
+     sudo useradd --system --no-create-home --shell /usr/sbin/nologin isolate
+     sudo usermod --add-subuids 524288-589823 --add-subgids 524288-589823 isolate
+
+     # Start the cgroup-keeper daemon installed by `make install`.
+     # The unit file is shipped to /usr/local/lib/systemd/system/,
+     # which systemd scans by default.
+     sudo systemctl daemon-reload
+     sudo systemctl enable --now isolate.service
+
+     # Smoke-test the install -- both commands should succeed.
+     sudo isolate --init --cg --box-id 0
+     sudo isolate --cleanup --cg --box-id 0
      ```
 
-   - other Linux distributions: build from source per the
-     [isolate README](https://github.com/ioi/isolate?tab=readme-ov-file#installation).
+     If `make all` emits Python `SyntaxWarning: invalid escape
+     sequence '\S'` lines, ignore them -- they come from the asciidoc
+     toolchain on Python 3.12+ and don't affect the build.
+
+     If `isolate --init` reports `Cannot open /run/isolate/cgroup`,
+     the cgroup-keeper service isn't running -- re-run the
+     `systemctl enable --now isolate.service` line above and check
+     `systemctl status isolate.service`.
+
+   - other Linux distributions: same procedure -- the package names
+     for the build dependencies vary, but `useradd`, `usermod
+     --add-subuids`, and `systemctl enable --now isolate.service`
+     are identical.  See the
+     [isolate README](https://github.com/ioi/isolate?tab=readme-ov-file#installation)
+     for distro-specific notes.
 
    - macOS / Windows: isolate is Linux-only.  Run the sandbox tests in a
      Linux VM or container.  The rest of the test suite still runs on the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,55 @@
+# Roadmap
+
+This file tracks larger architectural efforts in the generic-grader.
+Day-to-day work happens on individual issues; this is a coarse-grained
+view of the in-flight projects.
+
+## Sandbox isolation (Layer 3) — issue [#98](https://github.com/Purdue-EBEC/generic-grader/issues/98)
+
+**Status:** In progress. The single-PR effort delivers an
+`isolate`-backed sandbox that runs student submissions in a fresh
+process per call, with the legacy in-process path kept as the default
+until everything is wired through end-to-end.
+
+| Layer | What it does | Status |
+| ----- | ------------ | ------ |
+| 1 — pure patches | The legacy in-process patches in `utils/user.py` and `utils/patches.py`. Still the default. | Shipped. |
+| 2 — resource limits | `resource` / `signal`-based time and memory caps applied in-process. | Shipped. |
+| 3 — sandbox isolation | Length-prefixed JSON protocol; `isolate`-driven subprocess; Python runtime; Octave runtime stub; opt-in via `Options.use_sandbox=True`. | This PR. |
+
+### How to opt in
+
+Set `use_sandbox=True` on the `Options` for a given test.  Any patches
+that need to cross the sandbox boundary must be expressed as
+`PatchSpec` instances (see `generic_grader.sandbox.patch_specs`)
+because live callables can't be JSON-serialized.
+
+```python
+from generic_grader.sandbox.patch_specs import make_noop_patch_spec
+from generic_grader.utils.options import Options
+
+opts = Options(
+    use_sandbox=True,
+    patch_specs=(make_noop_patch_spec("submission.cleanup_temp_files"),),
+)
+```
+
+When `use_sandbox=False` (the default), the grader behaves exactly as
+it did before this PR.
+
+### What's next after this PR
+
+- **Octave runtime:** the stub in `sandbox/octave_runtime.py` returns
+  a structured "not implemented" error today.  Filling it in is a
+  straight swap.
+- **`ref_dir` bind-mount:** `Options.ref_dir` is defined now but only
+  consumed in a single test-resolution path.  The follow-up will
+  bind-mount it read-only under `/box/reference` so reference code
+  and submissions are properly isolated.
+- **Deprecate Layer 1 patches:** once Layer 3 is the default, the
+  legacy in-process patches should be removed from `utils/user.py`.
+
+## Other planned work
+
+See the [issue tracker](https://github.com/Purdue-EBEC/generic-grader/issues)
+for the full list.

--- a/src/generic_grader/sandbox/__init__.py
+++ b/src/generic_grader/sandbox/__init__.py
@@ -1,0 +1,14 @@
+"""Sandbox subsystem for running submitted code under `isolate`.
+
+This package provides:
+
+- `protocol`: language-agnostic request/response envelope and framing.
+- `python_runtime`: Python-specific worker that imports the submitted
+  module, calls a requested object, and captures structured events.
+- `worker`: stdio entrypoint that reads a request, dispatches by
+  `runtime`, and writes a response.
+- `runner` (forthcoming): host-side helper that spawns the worker under
+  `isolate` with the correct bind mounts and limits.
+
+See issue #98 for the design rationale.
+"""

--- a/src/generic_grader/sandbox/figure_facade.py
+++ b/src/generic_grader/sandbox/figure_facade.py
@@ -249,21 +249,29 @@ class SerializedAxes:
     def get_yaxis(self) -> _AxisStub:
         return _AxisStub(self._y_gridlines())
 
-    def _all_gridlines(self) -> list[_GridLineStub]:
-        return [_GridLineStub(v) for v in self._data.get("grid_lines", [])]
-
     def _x_gridlines(self) -> list[_GridLineStub]:
-        # The serialized format records gridlines that fall within
-        # ``xlim`` (first vertex's x in [xmin, xmax]).  We can't tell
-        # whether a given gridline is "x" or "y" from the wire format,
-        # so we hand both axes the full filtered list.  The plot helper
-        # (``get_grid_lines``) re-applies the same window filter, so
-        # double-counting is impossible -- each gridline reappears at
-        # most once in the output.
-        return self._all_gridlines()
+        # The serialized format keeps x-axis (vertical) and y-axis
+        # (horizontal) gridlines in separate fields so we can hand
+        # ``ax.get_xaxis().get_gridlines()`` exactly the set that the
+        # live matplotlib path would return.  Without this split,
+        # ``utils.plot.get_grid_lines`` double-counts gridlines
+        # whenever ``xlim`` and ``ylim`` overlap (e.g. both ranges
+        # include 0), because each gridline's first vertex then
+        # satisfies both the x and y window filters.
+        raw = self._data.get("x_grid_lines")
+        if raw is None:
+            # Backwards compatibility for figures serialized under the
+            # original ``grid_lines`` schema -- hand both axes the full
+            # list and accept the double-count.  Layer-3 always writes
+            # the new fields, so this path is exercised by legacy fixtures only.
+            raw = self._data.get("grid_lines", [])
+        return [_GridLineStub(v) for v in raw]
 
     def _y_gridlines(self) -> list[_GridLineStub]:
-        return self._all_gridlines()
+        raw = self._data.get("y_grid_lines")
+        if raw is None:
+            raw = self._data.get("grid_lines", [])
+        return [_GridLineStub(v) for v in raw]
 
     # --- Spines / legend -----------------------------------------------
     @property

--- a/src/generic_grader/sandbox/figure_facade.py
+++ b/src/generic_grader/sandbox/figure_facade.py
@@ -1,0 +1,300 @@
+"""Host-side facades that adapt serialized sandbox figures to matplotlib's API.
+
+The sandbox worker can't ship live ``matplotlib.figure.Figure`` objects
+across the IPC boundary, so it serializes them to JSON-safe dicts via
+``sandbox.figure_serializer``.  The grader's plot helpers in
+``generic_grader.utils.plot``, however, were written against the live
+matplotlib API (``ax.get_lines()``, ``ax.containers``, ``ax.patches``,
+``ax.spines``, etc.).
+
+Rather than rewrite every ``get_*`` helper to branch on "serialized vs
+live", we build thin facade objects here that quack like the axes /
+line / bar / wedge / spine objects the plot helpers reach into.  The
+plot helpers can then treat a sandbox-produced figure exactly like a
+live one.
+
+Only the surface that ``utils/plot.py`` actually touches is implemented
+-- if a new plot helper reaches into a previously-unused matplotlib
+attribute, this module will need a corresponding stub.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import matplotlib as mpl
+
+# ---------------------------------------------------------------------------
+# Small leaf facades
+# ---------------------------------------------------------------------------
+
+
+class _TextStub:
+    """Stand-in for a matplotlib ``Text`` (title, tick label, legend entry)."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def get_text(self) -> str:
+        return self._text
+
+
+class _LineStub:
+    """Stand-in for a matplotlib ``Line2D`` used by ``utils/plot.py``."""
+
+    def __init__(self, line: dict[str, Any]) -> None:
+        self._line = line
+
+    def get_xdata(self) -> list[float]:
+        return list(self._line.get("xdata", []))
+
+    def get_ydata(self) -> list[float]:
+        return list(self._line.get("ydata", []))
+
+    def get_color(self) -> Any:
+        name = self._line.get("color_name")
+        if name is not None:
+            return name
+        rgba = self._line.get("color_rgba")
+        if rgba is not None:
+            return tuple(rgba)
+        return (0.0, 0.0, 0.0, 1.0)
+
+
+class _RectangleStub(mpl.patches.Rectangle):
+    """A real Rectangle so ``isinstance(p, mpl.patches.Rectangle)`` works.
+
+    The plot helpers (``get_number_bars``, ``get_x_data``, etc.) filter
+    container patches with ``isinstance(patch, mpl.patches.Rectangle)``.
+    We subclass the real Rectangle and let it carry the geometry we
+    recorded in the serialized figure.
+    """
+
+    def __init__(self, x_center: float, width: float) -> None:
+        # Use a unit-height rectangle; only x/width are read downstream.
+        super().__init__((x_center - width / 2, 0.0), width, 1.0)
+
+
+class _BarContainerStub(mpl.container.BarContainer):
+    """A real BarContainer so ``isinstance(..., BarContainer)`` works."""
+
+    def __init__(self, bars: Sequence[dict[str, Any]], values: Sequence[float]) -> None:
+        patches = [_RectangleStub(b["x_center"], b["width"]) for b in bars]
+        super().__init__(patches, datavalues=tuple(values))
+
+
+class _WedgeStub(mpl.patches.Wedge):
+    """A real Wedge so ``isinstance(p, mpl.patches.Wedge)`` works.
+
+    ``utils/plot.py:get_pie_wedges`` filters axes patches with
+    ``isinstance(p, mpl.patches.Wedge)``, then asks for ``get_label``,
+    ``get_facecolor``, ``theta1``/``theta2``.  We hand-build a real
+    Wedge with the recorded label, color, and angle.
+    """
+
+    def __init__(self, wedge: dict[str, Any]) -> None:
+        # A unit-radius wedge centered at the origin; angles encode the
+        # serialized ``angle_degrees`` (theta2 - theta1).
+        super().__init__(
+            center=(0.0, 0.0),
+            r=1.0,
+            theta1=0.0,
+            theta2=float(wedge.get("angle_degrees", 0.0)),
+        )
+        self.set_label(wedge.get("label", ""))
+        # Drop alpha to match how to_hex round-trips.
+        self.set_facecolor(wedge.get("color_hex", "#000000"))
+
+
+class _GridLineStub:
+    """Stand-in for a gridline that exposes ``get_path().vertices``."""
+
+    class _Path:
+        def __init__(self, vertices: Sequence[Sequence[float]]) -> None:
+            self.vertices = [tuple(v) for v in vertices]
+
+    def __init__(self, vertices: Sequence[Sequence[float]]) -> None:
+        self._path = self._Path(vertices)
+
+    def get_visible(self) -> bool:
+        # All gridlines in the serialized dict were already filtered to
+        # the visible set by the worker, so we always return True here.
+        return True
+
+    def get_path(self) -> "_GridLineStub._Path":
+        return self._path
+
+
+class _AxisStub:
+    """Stand-in for ``ax.get_xaxis()`` / ``ax.get_yaxis()`` -- only
+    ``get_gridlines()`` is exercised by the plot helpers."""
+
+    def __init__(self, gridlines: Sequence[_GridLineStub]) -> None:
+        self._gridlines = list(gridlines)
+
+    def get_gridlines(self) -> list[_GridLineStub]:
+        return list(self._gridlines)
+
+
+class _SpineStub:
+    """Stand-in for a matplotlib ``Spine``."""
+
+    def __init__(self, visible: bool, position: Any) -> None:
+        # Encode visibility as ``visible flag * linewidth * alpha`` --
+        # the plot helper multiplies all three together, so setting
+        # the latter two to 1 when visible reproduces the live result.
+        self._visible = bool(visible)
+        self._position = position
+
+    def get_visible(self) -> bool:
+        return self._visible
+
+    def get_linewidth(self) -> float:
+        return 1.0 if self._visible else 0.0
+
+    def get_edgecolor(self) -> tuple[float, float, float, float]:
+        return (0.0, 0.0, 0.0, 1.0 if self._visible else 0.0)
+
+    def get_position(self) -> Any:
+        if isinstance(self._position, list):
+            return (self._position[0], self._position[1])
+        return self._position
+
+
+class _LegendStub:
+    """Stand-in for ``ax.get_legend()``; just needs ``.texts``."""
+
+    def __init__(self, labels: Sequence[str]) -> None:
+        self.texts = [_TextStub(label) for label in labels]
+
+
+# ---------------------------------------------------------------------------
+# Axes / Figure
+# ---------------------------------------------------------------------------
+
+
+class SerializedAxes:
+    """Facade that adapts one serialized axes dict to matplotlib's API.
+
+    Only the surface used by ``generic_grader.utils.plot`` is exposed.
+    The facade is read-only -- it does not mutate the underlying dict.
+    """
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+        # Lazily-built collections so repeated calls hand back the same
+        # stubs (matches matplotlib's behavior of returning identity-
+        # stable handles within a draw cycle).
+        self._lines: list[_LineStub] | None = None
+        self._containers: list[_BarContainerStub] | None = None
+        self._patches: list[Any] | None = None
+        self._spines: dict[str, _SpineStub] | None = None
+        self._title_text: _TextStub = _TextStub(data.get("title", ""))
+
+    # --- Title / labels -------------------------------------------------
+    @property
+    def title(self) -> _TextStub:
+        return self._title_text
+
+    def get_xlabel(self) -> str:
+        return self._data.get("xlabel", "")
+
+    def get_ylabel(self) -> str:
+        return self._data.get("ylabel", "")
+
+    # --- Limits ---------------------------------------------------------
+    def get_xlim(self) -> tuple[float, float]:
+        x0, x1 = self._data.get("xlim", [0.0, 1.0])
+        return (float(x0), float(x1))
+
+    def get_ylim(self) -> tuple[float, float]:
+        y0, y1 = self._data.get("ylim", [0.0, 1.0])
+        return (float(y0), float(y1))
+
+    # --- Tick labels ----------------------------------------------------
+    def get_xticklabels(self) -> list[_TextStub]:
+        return [_TextStub(t) for t in self._data.get("xticklabels", [])]
+
+    def get_yticklabels(self) -> list[_TextStub]:
+        return [_TextStub(t) for t in self._data.get("yticklabels", [])]
+
+    # --- Lines / containers / patches -----------------------------------
+    def get_lines(self) -> list[_LineStub]:
+        if self._lines is None:
+            self._lines = [_LineStub(line) for line in self._data.get("lines", [])]
+        return list(self._lines)
+
+    @property
+    def containers(self) -> list[_BarContainerStub]:
+        if self._containers is None:
+            bars = self._data.get("bars", []) or []
+            values = self._data.get("bar_values", []) or []
+            if bars:
+                self._containers = [_BarContainerStub(bars, values)]
+            else:
+                self._containers = []
+        return list(self._containers)
+
+    @property
+    def patches(self) -> list[Any]:
+        if self._patches is None:
+            self._patches = [_WedgeStub(w) for w in self._data.get("wedges", [])]
+        return list(self._patches)
+
+    # --- Axis / gridlines ----------------------------------------------
+    def get_xaxis(self) -> _AxisStub:
+        return _AxisStub(self._x_gridlines())
+
+    def get_yaxis(self) -> _AxisStub:
+        return _AxisStub(self._y_gridlines())
+
+    def _all_gridlines(self) -> list[_GridLineStub]:
+        return [_GridLineStub(v) for v in self._data.get("grid_lines", [])]
+
+    def _x_gridlines(self) -> list[_GridLineStub]:
+        # The serialized format records gridlines that fall within
+        # ``xlim`` (first vertex's x in [xmin, xmax]).  We can't tell
+        # whether a given gridline is "x" or "y" from the wire format,
+        # so we hand both axes the full filtered list.  The plot helper
+        # (``get_grid_lines``) re-applies the same window filter, so
+        # double-counting is impossible -- each gridline reappears at
+        # most once in the output.
+        return self._all_gridlines()
+
+    def _y_gridlines(self) -> list[_GridLineStub]:
+        return self._all_gridlines()
+
+    # --- Spines / legend -----------------------------------------------
+    @property
+    def spines(self) -> dict[str, _SpineStub]:
+        if self._spines is None:
+            visibility = self._data.get("spine_visibility", {}) or {}
+            positions = self._data.get("spine_positions", {}) or {}
+            self._spines = {
+                name: _SpineStub(visibility.get(name, False), positions.get(name))
+                for name in visibility
+            }
+        return dict(self._spines)
+
+    def get_legend(self) -> _LegendStub | None:
+        labels = self._data.get("legend")
+        if labels is None:
+            return None
+        return _LegendStub(labels)
+
+
+class SerializedFigure:
+    """Facade for a whole serialized figure (a list of axes dicts)."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def get_axes(self) -> list[SerializedAxes]:
+        return [SerializedAxes(ax) for ax in self._data.get("axes", [])]
+
+
+__all__ = (
+    "SerializedFigure",
+    "SerializedAxes",
+)

--- a/src/generic_grader/sandbox/figure_serializer.py
+++ b/src/generic_grader/sandbox/figure_serializer.py
@@ -49,7 +49,8 @@ Schema (version 1):
                     },
                     ...
                 ],
-                "grid_lines": [[[float, float], ...], ...],
+                "x_grid_lines": [[[float, float], ...], ...],
+                "y_grid_lines": [[[float, float], ...], ...],
                 "spine_visibility":  {name: bool, ...},
                 "spine_positions":   {name: [kind, value] | "zero" | "center", ...},
             },
@@ -195,8 +196,18 @@ def _serialize_tick_labels(getter) -> list[str]:
     return [label.get_text() for label in getter()]
 
 
-def _serialize_grid_lines(ax) -> list[list[list[float]]]:
-    """Return the visible grid lines filtered to the axes window."""
+def _serialize_grid_lines(
+    ax,
+) -> tuple[list[list[list[float]]], list[list[list[float]]]]:
+    """Return the visible grid lines filtered to the axes window.
+
+    Returns a ``(x_lines, y_lines)`` pair so the facade can keep the
+    two sets separate.  ``ax.get_xaxis().get_gridlines()`` returns the
+    *vertical* lines drawn at each x-tick (and vice versa for the
+    y-axis), so each set is filtered against the axis whose ticks
+    spawned the line -- exactly matching the logic in
+    ``utils.plot.get_grid_lines``.
+    """
     x_gridlines = ax.get_xaxis().get_gridlines()
     y_gridlines = ax.get_yaxis().get_gridlines()
     visible_x = [g for g in x_gridlines if g.get_visible()]
@@ -207,16 +218,17 @@ def _serialize_grid_lines(ax) -> list[list[list[float]]]:
     def to_vertices(line):
         return [[float(p[0]), float(p[1])] for p in line.get_path().vertices]
 
-    lines: list[list[list[float]]] = []
+    x_lines: list[list[list[float]]] = []
     for g in visible_x:
         vs = to_vertices(g)
         if vs and xmin <= vs[0][0] <= xmax:
-            lines.append(vs)
+            x_lines.append(vs)
+    y_lines: list[list[list[float]]] = []
     for g in visible_y:
         vs = to_vertices(g)
         if vs and ymin <= vs[0][1] <= ymax:
-            lines.append(vs)
-    return lines
+            y_lines.append(vs)
+    return x_lines, y_lines
 
 
 def _serialize_spine_visibility(ax) -> dict[str, bool]:
@@ -259,6 +271,7 @@ def _serialize_legend(ax) -> list[str] | None:
 
 def _serialize_axes(ax) -> dict[str, Any]:
     bars, bar_values = _serialize_bars(ax)
+    x_grid_lines, y_grid_lines = _serialize_grid_lines(ax)
     return {
         "title": ax.title.get_text(),
         "xlabel": ax.get_xlabel(),
@@ -272,7 +285,8 @@ def _serialize_axes(ax) -> dict[str, Any]:
         "bar_values": bar_values,
         "wedges": _serialize_wedges(ax),
         "legend": _serialize_legend(ax),
-        "grid_lines": _serialize_grid_lines(ax),
+        "x_grid_lines": x_grid_lines,
+        "y_grid_lines": y_grid_lines,
         "spine_visibility": _serialize_spine_visibility(ax),
         "spine_positions": _serialize_spine_positions(ax),
     }

--- a/src/generic_grader/sandbox/figure_serializer.py
+++ b/src/generic_grader/sandbox/figure_serializer.py
@@ -1,0 +1,309 @@
+"""Serialize a matplotlib Figure to a JSON-safe dict.
+
+The grader's existing plot tests reach into a live `plt.gcf()` to
+extract every property they care about (title, axes, line xdata/ydata,
+colors, bar widths, pie wedges, legend, grid lines, spine state,
+etc.). Those calls live in `generic_grader/utils/plot.py`.
+
+Once Layer 3 lands, the student's code runs in a separate sandboxed
+process. We cannot ship a `Figure` over a pipe; we ship a dict
+instead.  This module is responsible for producing that dict from
+inside the sandbox worker. The companion change in commit 6 will
+rewrite `utils/plot.py` to read from the same dict on the host side,
+so the surface area the grader code uses is unchanged.
+
+Schema (version 1):
+
+    {
+        "format":  "matplotlib-figure",
+        "version": 1,
+        "axes": [
+            {
+                "title":            str,
+                "xlabel":           str,
+                "ylabel":           str,
+                "xlim":             [float, float],
+                "ylim":             [float, float],
+                "xticklabels":      [str, ...],
+                "yticklabels":      [str, ...],
+                "legend":           [str, ...] | None,
+                "lines": [
+                    {
+                        "xdata":      [float, ...],
+                        "ydata":      [float, ...],
+                        "color_name": str | None,
+                        "color_rgba": [float, float, float, float] | None,
+                    },
+                    ...
+                ],
+                "bars": [
+                    {"x_center": float, "width": float},
+                    ...
+                ],
+                "bar_values":       [float, ...],
+                "wedges": [
+                    {
+                        "label":         str,
+                        "color_hex":     str,
+                        "angle_degrees": float,
+                    },
+                    ...
+                ],
+                "grid_lines": [[[float, float], ...], ...],
+                "spine_visibility":  {name: bool, ...},
+                "spine_positions":   {name: [kind, value] | "zero" | "center", ...},
+            },
+            ...
+        ]
+    }
+
+All numerical values are plain Python ``float`` / ``int`` -- never
+numpy scalars -- so the dict round-trips cleanly through ``json``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+
+FORMAT_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Scalar coercion
+# ---------------------------------------------------------------------------
+
+
+def _as_float(value: Any) -> float:
+    """Coerce numpy scalars / Python numbers to a plain ``float``."""
+    return float(value)
+
+
+def _as_float_list(values: Any) -> list[float]:
+    """Convert an iterable (incl. ndarray / MaskedArray) into a list of floats.
+
+    matplotlib stores ``xdata`` as raw ``datetime.date`` / ``datetime.datetime``
+    objects when the student calls ``plot(dates, ...)``. We coerce those
+    through ``date2num`` so the wire format is uniformly floats and the
+    host can re-hydrate dates with ``mpl.dates.num2date`` exactly like
+    the existing ``utils/plot.py:get_x_time_data`` does.
+    """
+    arr = np.asarray(values)
+    if arr.dtype == object:
+        # Likely a date array; convert via matplotlib's date helpers.
+        try:
+            arr = mpl.dates.date2num(arr)
+        except (TypeError, ValueError, AttributeError):
+            # Fall back to coercing element-by-element; anything that
+            # doesn't survive ``float()`` becomes a NaN.
+            out: list[float] = []
+            for v in arr.tolist():
+                try:
+                    out.append(float(v))
+                except (TypeError, ValueError):
+                    out.append(float("nan"))
+            return out
+    return [float(v) for v in np.asarray(arr, dtype=float).tolist()]
+
+
+# ---------------------------------------------------------------------------
+# Color helpers
+# ---------------------------------------------------------------------------
+
+
+# Computed once so each line lookup is a linear scan over a sorted list,
+# matching plot.get_line_colors exactly.
+_NAMED_COLORS = sorted(mpl.colors.get_named_colors_mapping().items())
+
+
+def _named_or_rgba(color: Any) -> tuple[str | None, list[float] | None]:
+    """Return ``(name, None)`` if a named color matches, else ``(None, rgba)``."""
+    for name, candidate in _NAMED_COLORS:
+        if mpl.colors.same_color(candidate, color):
+            return name, None
+    rgba = mpl.colors.to_rgba(color)
+    return None, [float(c) for c in rgba]
+
+
+# ---------------------------------------------------------------------------
+# Per-feature extractors
+# ---------------------------------------------------------------------------
+
+
+def _serialize_lines(ax) -> list[dict[str, Any]]:
+    lines: list[dict[str, Any]] = []
+    for line in ax.get_lines():
+        name, rgba = _named_or_rgba(line.get_color())
+        lines.append(
+            {
+                "xdata": _as_float_list(line.get_xdata()),
+                "ydata": [round(v, 6) for v in _as_float_list(line.get_ydata())],
+                "color_name": name,
+                "color_rgba": rgba,
+            }
+        )
+    return lines
+
+
+def _serialize_bars(ax) -> tuple[list[dict[str, Any]], list[float]]:
+    """Return ``(bars, datavalues)`` matching plot.get_x_data / get_y_data."""
+    containers = ax.containers
+    if not containers or not isinstance(containers[0], mpl.container.BarContainer):
+        return [], []
+    container = containers[0]
+    bars: list[dict[str, Any]] = []
+    for patch in container.patches:
+        if not isinstance(patch, mpl.patches.Rectangle):
+            continue
+        width = _as_float(patch.get_width())
+        x_center = _as_float(patch.get_x()) + width / 2
+        bars.append({"x_center": x_center, "width": width})
+    values = [round(_as_float(v), 6) for v in container.datavalues]
+    return bars, values
+
+
+def _serialize_wedges(ax) -> list[dict[str, Any]]:
+    wedges: list[dict[str, Any]] = []
+    for patch in ax.patches:
+        if not isinstance(patch, mpl.patches.Wedge):
+            continue
+        wedges.append(
+            {
+                "label": patch.get_label(),
+                "color_hex": mpl.colors.to_hex(patch.get_facecolor()),
+                "angle_degrees": round(
+                    _as_float(patch.theta2) - _as_float(patch.theta1), 4
+                ),
+            }
+        )
+    return wedges
+
+
+def _serialize_tick_labels(getter) -> list[str]:
+    return [label.get_text() for label in getter()]
+
+
+def _serialize_grid_lines(ax) -> list[list[list[float]]]:
+    """Return the visible grid lines filtered to the axes window."""
+    x_gridlines = ax.get_xaxis().get_gridlines()
+    y_gridlines = ax.get_yaxis().get_gridlines()
+    visible_x = [g for g in x_gridlines if g.get_visible()]
+    visible_y = [g for g in y_gridlines if g.get_visible()]
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+
+    def to_vertices(line):
+        return [[float(p[0]), float(p[1])] for p in line.get_path().vertices]
+
+    lines: list[list[list[float]]] = []
+    for g in visible_x:
+        vs = to_vertices(g)
+        if vs and xmin <= vs[0][0] <= xmax:
+            lines.append(vs)
+    for g in visible_y:
+        vs = to_vertices(g)
+        if vs and ymin <= vs[0][1] <= ymax:
+            lines.append(vs)
+    return lines
+
+
+def _serialize_spine_visibility(ax) -> dict[str, bool]:
+    visibility: dict[str, bool] = {}
+    for name, spine in ax.spines.items():
+        visible = spine.get_visible()
+        linewidth = spine.get_linewidth()
+        alpha_channel = spine.get_edgecolor()[3]
+        visibility[name] = bool(visible and linewidth and alpha_channel)
+    return visibility
+
+
+def _serialize_spine_positions(ax) -> dict[str, Any]:
+    """Return spine positions as JSON-safe tuples or strings.
+
+    Matplotlib stores spine positions either as a 2-tuple ``(kind,
+    amount)`` (e.g. ``('data', 0.5)``) or as one of the bare-string
+    shortcuts (``'zero'``, ``'center'``). We preserve both forms.
+    """
+    positions: dict[str, Any] = {}
+    for name, spine in ax.spines.items():
+        pos = spine.get_position()
+        if isinstance(pos, str):
+            positions[name] = pos
+        else:
+            kind, value = pos
+            positions[name] = [kind, _as_float(value)]
+    return positions
+
+
+def _serialize_legend(ax) -> list[str] | None:
+    legend = ax.get_legend()
+    return [t.get_text() for t in legend.texts] if legend else None
+
+
+# ---------------------------------------------------------------------------
+# Top-level
+# ---------------------------------------------------------------------------
+
+
+def _serialize_axes(ax) -> dict[str, Any]:
+    bars, bar_values = _serialize_bars(ax)
+    return {
+        "title": ax.title.get_text(),
+        "xlabel": ax.get_xlabel(),
+        "ylabel": ax.get_ylabel(),
+        "xlim": [_as_float(v) for v in ax.get_xlim()],
+        "ylim": [_as_float(v) for v in ax.get_ylim()],
+        "xticklabels": _serialize_tick_labels(ax.get_xticklabels),
+        "yticklabels": _serialize_tick_labels(ax.get_yticklabels),
+        "lines": _serialize_lines(ax),
+        "bars": bars,
+        "bar_values": bar_values,
+        "wedges": _serialize_wedges(ax),
+        "legend": _serialize_legend(ax),
+        "grid_lines": _serialize_grid_lines(ax),
+        "spine_visibility": _serialize_spine_visibility(ax),
+        "spine_positions": _serialize_spine_positions(ax),
+    }
+
+
+def serialize_figure(fig) -> dict[str, Any]:
+    """Serialize a matplotlib ``Figure`` to a JSON-safe dict.
+
+    The caller (the sandbox worker) is responsible for invoking this
+    before closing the figure.  Tick labels require a draw to be
+    populated, so the function forces ``canvas.draw()`` first --
+    exactly like the existing ``get_x_tick_labels`` and friends in
+    ``utils/plot.py``.
+    """
+    try:
+        fig.canvas.draw()
+    except Exception:  # pragma: no cover - draw failure is best-effort
+        pass
+
+    axes_data = [_serialize_axes(ax) for ax in fig.get_axes()]
+    return {
+        "format": "matplotlib-figure",
+        "version": FORMAT_VERSION,
+        "axes": axes_data,
+    }
+
+
+def serialize_current_figures() -> list[dict[str, Any]]:
+    """Serialize every open pyplot figure, then close them all.
+
+    Returns a list (possibly empty) of serialized figure dicts in the
+    order matplotlib reports them. After this call ``plt.get_fignums()``
+    is empty, so a subsequent worker run starts clean.
+    """
+    serialized: list[dict[str, Any]] = []
+    for num in plt.get_fignums():
+        fig = plt.figure(num)
+        serialized.append(serialize_figure(fig))
+    plt.close("all")
+    return serialized
+
+
+__all__ = ("serialize_figure", "serialize_current_figures", "FORMAT_VERSION")

--- a/src/generic_grader/sandbox/figure_serializer.py
+++ b/src/generic_grader/sandbox/figure_serializer.py
@@ -149,7 +149,16 @@ def _serialize_lines(ax) -> list[dict[str, Any]]:
 
 
 def _serialize_bars(ax) -> tuple[list[dict[str, Any]], list[float]]:
-    """Return ``(bars, datavalues)`` matching plot.get_x_data / get_y_data."""
+    """Return ``(bars, datavalues)`` matching plot.get_x_data / get_y_data.
+
+    This intentionally inspects only ``containers[0]`` to match
+    ``utils/plot.py`` (see ``get_bars``, ``get_bar_values``, and
+    ``get_bar_dates`` there).  Grouped bar charts that produce multiple
+    ``BarContainer``s will only have the first group reported, which is
+    the same trade-off the existing in-process plot helpers already
+    make.  Changing this behaviour belongs in a follow-up that updates
+    both layers together.
+    """
     containers = ax.containers
     if not containers or not isinstance(containers[0], mpl.container.BarContainer):
         return [], []
@@ -278,16 +287,24 @@ def serialize_figure(fig) -> dict[str, Any]:
     exactly like the existing ``get_x_tick_labels`` and friends in
     ``utils/plot.py``.
     """
+    draw_succeeded = True
+    draw_error: str | None = None
     try:
         fig.canvas.draw()
-    except Exception:  # pragma: no cover - draw failure is best-effort
-        pass
+    except Exception as e:  # pragma: no cover - draw failure is best-effort
+        draw_succeeded = False
+        # Record the failure type and message so a host-side test
+        # author has something concrete to inspect when tick labels or
+        # other draw-dependent properties come back blank.
+        draw_error = f"{type(e).__name__}: {e}"
 
     axes_data = [_serialize_axes(ax) for ax in fig.get_axes()]
     return {
         "format": "matplotlib-figure",
         "version": FORMAT_VERSION,
         "axes": axes_data,
+        "draw_succeeded": draw_succeeded,
+        "draw_error": draw_error,
     }
 
 

--- a/src/generic_grader/sandbox/integration.py
+++ b/src/generic_grader/sandbox/integration.py
@@ -89,6 +89,31 @@ def get_default_box_pool() -> BoxPool:
     return _DEFAULT_POOL
 
 
+def pool_for_xdist_worker(
+    worker_id: str, *, size: int = DEFAULT_BOX_POOL_SIZE
+) -> BoxPool:
+    """Build a :class:`BoxPool` for a pytest-xdist worker.
+
+    Each worker gets a disjoint range of ``box_id`` slots so concurrent
+    workers never try to ``isolate --init`` the same box.  The default
+    (master) ``worker_id == "master"`` -- i.e. no xdist -- maps to
+    base 0 to match the historical single-process behavior.
+
+    The ``worker_id`` follows the pytest-xdist convention: ``"master"``
+    for the main process, ``"gw0"``/``"gw1"``/... for parallel workers.
+    """
+    if worker_id == "master" or not worker_id.startswith("gw"):
+        return BoxPool(size=size, base=0)
+    try:
+        index = int(worker_id[2:])
+    except ValueError as e:
+        raise ValueError(
+            f"unrecognized xdist worker_id {worker_id!r}; "
+            "expected 'master' or 'gw<N>'"
+        ) from e
+    return BoxPool(size=size, base=index * size)
+
+
 # ---------------------------------------------------------------------------
 # Result shape
 # ---------------------------------------------------------------------------

--- a/src/generic_grader/sandbox/integration.py
+++ b/src/generic_grader/sandbox/integration.py
@@ -1,0 +1,499 @@
+"""Host-side glue between the existing `Importer` / `User` API and the sandbox.
+
+This module is the bridge enabled by ``Options.use_sandbox=True``.  It
+mirrors the same student-facing contracts as the in-process Layer 1
+path:
+
+* ``sandbox_import_obj`` performs an import-only run in a fresh
+  sandbox.  Any module-level ``input()`` call is classified as
+  "stuck at input during import", matching the legacy
+  :class:`generic_grader.utils.importer.Importer.InputError` flow.
+* ``sandbox_call_obj`` runs the student's callable in a *separate*
+  fresh sandbox.  Stdout / stdin events from the worker are replayed
+  into the same `LogIO` and `interactions` data structures that the
+  existing `__User__` already maintains, so downstream methods
+  (``read_log_line``, ``get_value``, ``format_log``) keep working.
+
+Each call gets its own sandbox box (the box pool below hands out
+disjoint ``box_id``s) so concurrent test runners under
+``pytest-xdist`` never collide on isolate state.
+
+Nothing in this module *replaces* `Importer` or `__User__` directly --
+that wiring (turning the ``Options.use_sandbox`` flag into the routing
+decision) is the job of commit 5d.  Keeping the integration module
+free of any `Importer`/`User` reference also makes it the place we
+unit-test the sandbox path in isolation.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterator, Optional, Sequence
+
+from generic_grader.sandbox.protocol import PatchSpec, Request, Response
+from generic_grader.sandbox.runner import IsolateRunner
+from generic_grader.utils.exceptions import EndOfInputError, ExtraEntriesError
+from generic_grader.utils.options import Options
+
+# ---------------------------------------------------------------------------
+# Box pool
+# ---------------------------------------------------------------------------
+
+# isolate boxes live at /var/local/lib/isolate/<box_id>; concurrent
+# graders need disjoint ids.  The pool below hands them out and
+# returns them so a pytest-xdist worker can hold a single id across
+# its (sequential) test cases.
+
+DEFAULT_BOX_POOL_SIZE = 64
+
+
+class BoxPool:
+    """A thread-safe pool of integer ``box_id`` slots for isolate.
+
+    `acquire` blocks until a slot is free; `release` returns it.  The
+    pool is bounded so we don't run away with arbitrary ids on a host
+    where the isolate config restricts ``num_boxes``.
+
+    The pool is not multi-process aware on its own -- the assumption
+    is that pytest-xdist worker N pins its acquisitions to a stable
+    base offset (handled by `pool_for_xdist_worker` below).
+    """
+
+    def __init__(self, size: int = DEFAULT_BOX_POOL_SIZE, base: int = 0) -> None:
+        if size < 1:
+            raise ValueError(f"BoxPool size must be >= 1; got {size}")
+        if base < 0:
+            raise ValueError(f"BoxPool base must be >= 0; got {base}")
+        self._available: list[int] = list(range(base, base + size))
+        self._cv = threading.Condition()
+
+    def acquire(self) -> int:
+        with self._cv:
+            while not self._available:
+                self._cv.wait()
+            return self._available.pop()
+
+    def release(self, box_id: int) -> None:
+        with self._cv:
+            self._available.append(box_id)
+            self._cv.notify()
+
+
+_DEFAULT_POOL = BoxPool()
+
+
+def get_default_box_pool() -> BoxPool:
+    """Return the process-wide default :class:`BoxPool`."""
+    return _DEFAULT_POOL
+
+
+# ---------------------------------------------------------------------------
+# Result shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SandboxRunResult:
+    """The host-side view of a single sandbox run.
+
+    After a call returns, the caller has:
+
+    * ``return_value`` -- the JSON-decoded return (or ``None`` for
+      non-serializable returns; check ``return_event`` for the repr).
+    * ``log`` -- the reconstructed IO log (stdout interleaved with
+      stdin responses, just like the in-process `LogIO`).
+    * ``interactions`` -- list of offsets into ``log`` marking each
+      ``input()`` prompt boundary.
+    * ``unused_entries`` -- count of simulated entries the student
+      didn't consume; nonzero means an `ExtraEntriesError` should be
+      raised by the caller.
+    * ``exception`` -- the structured exception chain, or ``None`` on
+      success.
+    * ``response`` -- the raw `Response` for advanced inspection.
+    """
+
+    return_value: Any = None
+    return_non_serializable: bool = False
+    return_repr: Optional[str] = None
+    log: str = ""
+    interactions: list[int] = field(default_factory=list)
+    unused_entries: int = 0
+    exception: Optional[list[dict[str, Any]]] = None
+    figures: list[dict[str, Any]] = field(default_factory=list)
+    elapsed_seconds: float = 0.0
+    response: Optional[Response] = None
+    consumed_input_during_import: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Event-stream replay
+# ---------------------------------------------------------------------------
+
+
+def _replay_events(response: Response) -> SandboxRunResult:
+    """Walk a `Response.events` list and project it into a `SandboxRunResult`.
+
+    The event order mirrors the order things happened in the worker,
+    which lets us reconstruct the same interleaving of stdout writes
+    and ``input()`` calls that the in-process path produces.
+    """
+    result = SandboxRunResult(
+        exception=response.exception,
+        elapsed_seconds=response.elapsed_seconds,
+        response=response,
+    )
+    log_parts: list[str] = []
+    log_length = 0
+    # Mirrors the existing __User__: a leading 0 marker means "log
+    # position before any input prompt".
+    interactions: list[int] = [0]
+    saw_input_event = False
+    current_phase = "import"
+
+    for event in response.events:
+        if event.type == "phase":
+            current_phase = event.extra.get("name") or current_phase
+            continue
+        if event.type == "stdout":
+            data = event.extra.get("data", "")
+            log_parts.append(data)
+            log_length += len(data)
+        elif event.type == "stderr":
+            # The legacy path doesn't merge stderr into the IO log
+            # (it patches sys.stdout only).  Keep parity here.
+            continue
+        elif event.type == "stdin":
+            # input() was called: record the log offset (where the
+            # next prompt began -- already accounted for by the
+            # preceding stdout write) and append the entered text
+            # followed by a newline, matching the legacy responder.
+            interactions.append(log_length)
+            entry = event.extra.get("data", "")
+            line = f"{entry}\n"
+            log_parts.append(line)
+            log_length += len(line)
+            if current_phase == "import":
+                saw_input_event = True
+        elif event.type == "return":
+            if event.extra.get("non_serializable"):
+                result.return_non_serializable = True
+                result.return_repr = event.extra.get("repr")
+            else:
+                result.return_value = event.extra.get("value")
+        elif event.type == "figure":
+            result.figures.append(event.extra.get("properties", {}))
+        elif event.type == "unused_entries":
+            result.unused_entries = int(event.extra.get("count", 0))
+
+    result.log = "".join(log_parts)
+    result.interactions = interactions
+    result.consumed_input_during_import = saw_input_event
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Request construction
+# ---------------------------------------------------------------------------
+
+
+def _resolve_submission_dir(options: Options, module: str) -> str:
+    """Return the directory the worker should bind-mount as the submission.
+
+    The legacy importer imports student code from `cwd` (set by the
+    test harness).  When ``Options.use_sandbox=True`` we bind that
+    same directory in read-write under ``/box/submission``.  Module
+    paths supplied via dotted names (e.g. ``tests.reference``) are
+    handled by adjusting the package directory below.
+    """
+    cwd = Path.cwd()
+    if "." in module:
+        # Dotted module: the package root must contain the topmost
+        # package directory.  We climb until the topmost package's
+        # parent is on disk.
+        top, *_ = module.split(".")
+        candidate = cwd / top
+        if candidate.exists():
+            return str(cwd)
+        # Fall through to cwd; the worker will raise ModuleNotFoundError
+        # and the caller surfaces the structured exception.
+    return str(cwd)
+
+
+def _build_request(
+    *,
+    runtime: str,
+    submission_dir: str,
+    module: str,
+    obj_name: str,
+    options: Options,
+    args: Sequence[Any] = (),
+    kwargs: Optional[dict[str, Any]] = None,
+    entries: Sequence[str] = (),
+    patch_specs: Sequence[PatchSpec] = (),
+    captures: Sequence[str] = ("stdout", "stderr", "return", "figures"),
+) -> Request:
+    """Build a :class:`Request` from `Options`, factoring out parameter pass-through."""
+    return Request(
+        runtime=runtime,
+        submission_dir=submission_dir,
+        module=module,
+        obj_name=obj_name,
+        args=tuple(args),
+        kwargs=dict(kwargs or {}),
+        entries=tuple(entries),
+        fixed_time=(
+            options.fixed_time
+            if isinstance(options.fixed_time, str)
+            else (options.fixed_time.isoformat() if options.fixed_time else None)
+        ),
+        time_limit_seconds=float(options.time_limit),
+        memory_limit_mb=int(options.memory_limit_GB * 1024),
+        log_limit=int(options.log_limit or 0),
+        captures=tuple(captures),
+        patch_specs=tuple(patch_specs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runner factory (overridable for tests)
+# ---------------------------------------------------------------------------
+
+# A factory that returns a configured `IsolateRunner`.  Tests inject a
+# fake runner; production code uses `default_runner_factory` which
+# resolves the grader source directory from this module's location.
+RunnerFactory = Callable[[int], "IsolateRunnerLike"]
+
+
+class IsolateRunnerLike:  # pragma: no cover - structural typing only
+    def run(self, request: Request) -> Response: ...
+
+
+def _grader_src_root() -> str:
+    """Return the directory containing the ``generic_grader`` package."""
+    # ``__file__`` is .../generic_grader/sandbox/integration.py; we
+    # want the directory that *contains* the package so the worker's
+    # PYTHONPATH = /box/grader resolves ``import generic_grader``.
+    return str(Path(__file__).resolve().parent.parent.parent)
+
+
+def default_runner_factory(box_id: int) -> IsolateRunner:
+    """Default factory: a fresh :class:`IsolateRunner` per call.
+
+    The runner does its own init/cleanup of the isolate box per
+    ``run()``, so reusing one instance across calls is safe.  We
+    still build a new one each time to keep the integration module
+    stateless from the caller's perspective.
+    """
+    return IsolateRunner(grader_src=_grader_src_root(), box_id=box_id)
+
+
+# ---------------------------------------------------------------------------
+# Public API: import_obj / call_obj equivalents
+# ---------------------------------------------------------------------------
+
+
+def sandbox_import_obj(
+    module: str,
+    options: Options,
+    *,
+    runner_factory: Optional[RunnerFactory] = None,
+    box_pool: Optional[BoxPool] = None,
+) -> SandboxRunResult:
+    """Run an import-only probe of `module` inside a fresh sandbox.
+
+    The probe imports `module` and resolves ``options.obj_name``.  Any
+    ``input()`` call during import is recorded as a structured event
+    (the worker patches ``builtins.input`` to consume from the
+    Request's ``entries``, which we leave empty so the first call
+    raises ``EOFError`` -- the worker's protocol-level analogue of
+    Layer 1's ``Importer.InputError``).
+
+    Returns a :class:`SandboxRunResult` so callers can decide how to
+    classify the outcome.  Commit 5d turns those classifications into
+    the matching student-facing test failures.
+    """
+    factory = runner_factory or default_runner_factory
+    pool = box_pool or _DEFAULT_POOL
+    submission_dir = _resolve_submission_dir(options, module)
+
+    # Use a target that resolves immediately without invoking student
+    # code: importing the module and getattr()ing obj_name happens
+    # before the worker tries to call anything.  We pick a no-op
+    # placeholder for the "call" by asking the worker to import only;
+    # to keep the wire protocol simple we instead invoke the
+    # resolved object with no args/kwargs but disable the call by
+    # patching it with a noop spec whose target is the same dotted
+    # path.
+    #
+    # In practice that's overkill: we just need to know whether the
+    # import succeeds and whether the module-level code calls
+    # ``input()``.  Calling the object with empty args is acceptable
+    # because the in-process path *also* calls it (via getattr +
+    # return).  But the legacy importer does NOT call the object --
+    # it returns it.  To preserve that contract we patch the resolved
+    # name with a noop so the worker's call phase is a no-op.
+    obj_name = options.obj_name
+    import_only_spec = PatchSpec(target=f"{module}.{obj_name}", kind="noop")
+
+    request = _build_request(
+        runtime="python",
+        submission_dir=submission_dir,
+        module=module,
+        obj_name=obj_name,
+        options=options,
+        args=(),
+        kwargs={},
+        entries=(),
+        patch_specs=(import_only_spec, *options.patch_specs),
+        # During import we don't need figures or return values.
+        captures=("stdout", "stderr"),
+    )
+
+    box_id = pool.acquire()
+    try:
+        runner = factory(box_id)
+        response = runner.run(request)
+    finally:
+        pool.release(box_id)
+
+    return _replay_events(response)
+
+
+def sandbox_call_obj(
+    module: str,
+    options: Options,
+    *,
+    runner_factory: Optional[RunnerFactory] = None,
+    box_pool: Optional[BoxPool] = None,
+    entries: Optional[Sequence[str]] = None,
+) -> SandboxRunResult:
+    """Run ``module.obj_name(*args, **kwargs)`` inside a fresh sandbox.
+
+    A *new* sandbox box is allocated for this call (independent of any
+    earlier `sandbox_import_obj`).  The worker captures stdout, stdin
+    echoes, return values, and any open matplotlib figures, and the
+    result is replayed into a `SandboxRunResult` for downstream
+    consumption by `__User__`.
+
+    `entries` overrides ``options.entries`` (used by the legacy path
+    when the caller wants to short-circuit the simulated input).
+    """
+    factory = runner_factory or default_runner_factory
+    pool = box_pool or _DEFAULT_POOL
+    submission_dir = _resolve_submission_dir(options, module)
+    effective_entries = (
+        tuple(entries) if entries is not None else tuple(options.entries or ())
+    )
+
+    request = _build_request(
+        runtime="python",
+        submission_dir=submission_dir,
+        module=module,
+        obj_name=options.obj_name,
+        options=options,
+        args=tuple(options.args or ()),
+        kwargs=dict(options.kwargs or {}),
+        entries=effective_entries,
+        patch_specs=tuple(options.patch_specs or ()),
+    )
+
+    box_id = pool.acquire()
+    try:
+        runner = factory(box_id)
+        response = runner.run(request)
+    finally:
+        pool.release(box_id)
+
+    return _replay_events(response)
+
+
+# ---------------------------------------------------------------------------
+# Error classification helpers
+# ---------------------------------------------------------------------------
+
+
+def classify_import_outcome(result: SandboxRunResult) -> Optional[type[BaseException]]:
+    """Map a `SandboxRunResult` from import to a Python exception type.
+
+    Returns ``None`` on success.  The mapping mirrors the legacy
+    `Importer.import_obj` classification:
+
+    * Module-level ``input()`` call -> ``EndOfInputError`` (host
+      callers translate this into the "stuck at input during
+      import" failure path).
+    * Any other structured exception -> the matching class resolved
+      from `result.exception[0]["type"]`, or ``Exception`` as a
+      fallback when the class isn't importable on the host.
+    """
+    if result.consumed_input_during_import:
+        return EndOfInputError
+    if not result.exception:
+        return None
+    head = result.exception[0]
+    if head.get("type") == "EOFError":
+        # The worker's responder raises EOFError when entries are
+        # exhausted -- this is the protocol-level signal for "stuck
+        # at input during import" since import_obj sends entries=().
+        return EndOfInputError
+    return _resolve_exception_class(head.get("type") or "")
+
+
+def classify_call_outcome(result: SandboxRunResult) -> Optional[type[BaseException]]:
+    """Map a call-phase `SandboxRunResult` to a Python exception type."""
+    if not result.exception and result.unused_entries:
+        return ExtraEntriesError
+    if not result.exception:
+        return None
+    head = result.exception[0]
+    return _resolve_exception_class(head.get("type") or "")
+
+
+def _resolve_exception_class(name: str) -> type[BaseException]:
+    """Best-effort lookup of an exception class by short name.
+
+    Falls back to a generic ``Exception`` if the name isn't in the
+    builtins or in `generic_grader.utils.exceptions` -- the
+    structured chain still carries the message, so downstream
+    formatters lose only the type for unknown classes.
+    """
+    import builtins as _b
+
+    cls = getattr(_b, name, None)
+    if isinstance(cls, type) and issubclass(cls, BaseException):
+        return cls
+    try:
+        import generic_grader.utils.exceptions as _exc_mod
+    except ImportError:  # pragma: no cover - defensive
+        return Exception
+    cls = getattr(_exc_mod, name, None)
+    if isinstance(cls, type) and issubclass(cls, BaseException):
+        return cls
+    return Exception
+
+
+# ---------------------------------------------------------------------------
+# Iterator helper (used by tests; kept here so the public surface is
+# import-clean even when the worker isn't installed)
+# ---------------------------------------------------------------------------
+
+
+def iter_events(response: Response) -> Iterator[dict[str, Any]]:
+    """Yield each event from `response` as a plain dict."""
+    for event in response.events:
+        yield event.to_dict()
+
+
+__all__ = (
+    "BoxPool",
+    "DEFAULT_BOX_POOL_SIZE",
+    "SandboxRunResult",
+    "classify_call_outcome",
+    "classify_import_outcome",
+    "default_runner_factory",
+    "get_default_box_pool",
+    "iter_events",
+    "sandbox_call_obj",
+    "sandbox_import_obj",
+)

--- a/src/generic_grader/sandbox/integration.py
+++ b/src/generic_grader/sandbox/integration.py
@@ -228,7 +228,7 @@ def _resolve_submission_dir(options: Options, module: str) -> str:
 
     The legacy importer imports student code from `cwd` (set by the
     test harness).  When ``Options.use_sandbox=True`` we bind that
-    same directory in read-write under ``/box/submission``.  Module
+    same directory in read-write under ``/submission``.  Module
     paths supplied via dotted names (e.g. ``tests.reference``) are
     handled by adjusting the package directory below.
     """
@@ -299,7 +299,7 @@ def _grader_src_root() -> str:
     """Return the directory containing the ``generic_grader`` package."""
     # ``__file__`` is .../generic_grader/sandbox/integration.py; we
     # want the directory that *contains* the package so the worker's
-    # PYTHONPATH = /box/grader resolves ``import generic_grader``.
+    # PYTHONPATH = /grader resolves ``import generic_grader``.
     return str(Path(__file__).resolve().parent.parent.parent)
 
 

--- a/src/generic_grader/sandbox/octave_runtime.py
+++ b/src/generic_grader/sandbox/octave_runtime.py
@@ -1,0 +1,54 @@
+"""Octave runtime stub for forward compatibility.
+
+Layer 3 was designed with a runtime selector (`Request.runtime`) so a
+future commit can hook the same sandbox infrastructure up to GNU
+Octave.  Issue #98 only delivers the Python runtime, but the protocol
+already accepts a ``runtime`` string and the worker dispatcher needs
+to know what to do when a host sends ``runtime="octave"``.
+
+Rather than crash the worker with an opaque ``AttributeError`` when a
+future host (or a misconfigured grader) requests Octave, we register
+this stub.  It returns a well-formed :class:`Response` whose only
+content is a structured ``RuntimeNotImplementedError`` exception, so
+the host's existing error-classification path can surface a clean
+message to the student or test author.
+
+When the real Octave runtime lands, this module will be replaced by
+the corresponding implementation; the dispatcher contract
+(``run_request(request: Request) -> Response``) is intentionally the
+same as the Python runtime's, so the swap will be a one-line change
+in ``worker_main``.
+"""
+
+from __future__ import annotations
+
+from generic_grader.sandbox.protocol import Request, Response
+
+
+def run_request(request: Request) -> Response:
+    """Return a structured error response for the not-yet-built Octave runtime.
+
+    The host sees the same shape of response it would see for any
+    other runtime-level failure: an empty event list and a non-empty
+    ``exception`` chain.  The error type is deliberately specific so
+    callers can distinguish "Octave isn't built yet" from a generic
+    SandboxRunError.
+    """
+    return Response(
+        events=[],
+        exception=[
+            {
+                "type": "RuntimeNotImplementedError",
+                "message": (
+                    "The Octave runtime is not implemented yet "
+                    "(see issue #98).  Use `runtime='python'` until the "
+                    "Octave worker lands."
+                ),
+                "traceback": "",
+            }
+        ],
+        elapsed_seconds=0.0,
+    )
+
+
+__all__ = ("run_request",)

--- a/src/generic_grader/sandbox/patch_specs.py
+++ b/src/generic_grader/sandbox/patch_specs.py
@@ -1,0 +1,122 @@
+"""Host-side helpers for building `PatchSpec` instances.
+
+These mirror the existing `make_mock_function_*` helpers in
+`generic_grader.utils.mocks`, but emit JSON-serializable
+:class:`~generic_grader.sandbox.protocol.PatchSpec` records instead of
+live ``(target, callable)`` tuples.  The same spec format is consumed
+by both the in-process path (``custom_stack`` rebuilds a mock from the
+spec) and the sandboxed path (the worker rebuilds the same mock inside
+the sandbox).
+
+Use these in tests where ``Options.use_sandbox=True`` is set, or for
+new code that wants its patches to be sandbox-portable from day one.
+"""
+
+from __future__ import annotations
+
+import inspect
+import textwrap
+from typing import Any, Callable
+
+from generic_grader.sandbox.protocol import PatchSpec
+
+
+def make_noop_patch_spec(
+    target: str, *, patch_kwargs: dict[str, Any] | None = None
+) -> PatchSpec:
+    """Spec for a patch that replaces `target` with a no-op."""
+    return PatchSpec(target=target, kind="noop", patch_kwargs=dict(patch_kwargs or {}))
+
+
+def make_iter_patch_spec(
+    target: str,
+    values: list[Any],
+    *,
+    patch_kwargs: dict[str, Any] | None = None,
+) -> PatchSpec:
+    """Spec for a patch that yields successive `values` then raises.
+
+    The reconstructed mock returns the next item in `values` on each
+    call and raises ``ExcessFunctionCallError`` once `values` is
+    exhausted, matching the existing :func:`make_mock_function` helper.
+    """
+    return PatchSpec(
+        target=target,
+        kind="iter_returns",
+        values=list(values),
+        patch_kwargs=dict(patch_kwargs or {}),
+    )
+
+
+def make_raise_error_patch_spec(
+    target: str,
+    error: type[BaseException],
+    *,
+    patch_kwargs: dict[str, Any] | None = None,
+) -> PatchSpec:
+    """Spec for a patch that raises `error` on every call.
+
+    `error` must be importable by dotted path on the worker side; the
+    spec serializes the qualified name (``module.Class``).
+    """
+    if not isinstance(error, type) or not issubclass(error, BaseException):
+        raise TypeError(f"`error` must be an exception class; got {error!r}")
+    qualname = f"{error.__module__}.{error.__qualname__}"
+    return PatchSpec(
+        target=target,
+        kind="raise_error",
+        error_qualname=qualname,
+        patch_kwargs=dict(patch_kwargs or {}),
+    )
+
+
+def make_source_patch_spec(
+    target: str,
+    func: Callable[..., Any],
+    *,
+    patch_kwargs: dict[str, Any] | None = None,
+) -> PatchSpec:
+    """Spec for a patch defined by the source of a host-side function.
+
+    The function's source is captured via :func:`inspect.getsource`
+    and shipped to the worker, which exec's it in an empty namespace
+    and pulls out the function by name.  This is the escape hatch for
+    assignment-specific patches (e.g. a fake physics function) that
+    don't fit one of the predefined templates.
+
+    Restrictions
+    ------------
+    - `func` must be defined at module scope (or be otherwise
+      retrievable by :func:`inspect.getsource`).
+    - `func` may not be a closure: its source is executed in an empty
+      namespace inside the sandbox, so it can't depend on any
+      enclosing-scope variables.
+    """
+    if not callable(func):
+        raise TypeError(f"`func` must be callable; got {func!r}")
+    try:
+        raw = inspect.getsource(func)
+    except (OSError, TypeError) as e:
+        raise ValueError(f"Cannot capture source for {func!r}: {e}") from e
+    source = textwrap.dedent(raw)
+    name = getattr(func, "__name__", None)
+    if not name or name == "<lambda>":
+        raise ValueError(
+            "Patch source functions must have a real `__name__`; "
+            "lambdas and anonymous functions can't cross the sandbox."
+        )
+    return PatchSpec(
+        target=target,
+        kind="source",
+        source=source,
+        name=name,
+        patch_kwargs=dict(patch_kwargs or {}),
+    )
+
+
+__all__ = (
+    "make_iter_patch_spec",
+    "make_noop_patch_spec",
+    "make_raise_error_patch_spec",
+    "make_source_patch_spec",
+)

--- a/src/generic_grader/sandbox/protocol.py
+++ b/src/generic_grader/sandbox/protocol.py
@@ -1,0 +1,322 @@
+"""IPC protocol between the grader (host) and the sandboxed worker.
+
+Wire format
+-----------
+
+A *frame* is a decimal byte length, a single newline, then exactly that
+many bytes of payload::
+
+    18\\n{"hello": "world"}
+
+This keeps newlines inside the JSON payload (e.g. captured `print`
+output containing ``\\n``) from corrupting frame boundaries.
+
+A *request* is a single framed JSON object sent from host to worker.
+A *response* is a single framed JSON object sent the other way. There
+is no streaming: the host writes one request, the worker writes one
+response, both processes exit (the worker is restarted under a fresh
+sandbox for the next test).
+
+Envelopes
+---------
+
+`Request` carries everything the worker needs to run the test:
+runtime selector, submission directory, module name, callable to invoke,
+positional / keyword arguments, simulated stdin entries, resource
+limits, fixed time, and a `captures` whitelist that lets the host
+opt particular event types in or out (so e.g. plot tests can skip
+stdout capture overhead).
+
+`Response` carries an ordered list of `Event` records, an `elapsed_seconds`
+float, and an optional `exception` chain (one entry per link of the
+chain; each entry has type, message, and a sanitized traceback string).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, BinaryIO, Iterable
+
+PROTOCOL_VERSION = 1
+
+_DEFAULT_CAPTURES = ("stdout", "stderr", "return", "figures", "exception")
+
+
+class SandboxException(Exception):
+    """Raised on any protocol-level error (framing, version mismatch, …).
+
+    Worker-side or host-side translation of *student* exceptions does
+    *not* use this class; those are serialized into the response body
+    as a structured `exception` chain.
+    """
+
+    @staticmethod
+    def serialized_chain(chain):
+        """Identity helper for readability at call sites.
+
+        The chain is just a list of dicts at the wire level; this method
+        exists so callers can write `SandboxException.serialized_chain(...)`
+        and convey intent.  It performs no transformation.
+        """
+        return list(chain)
+
+
+# ---------------------------------------------------------------------------
+# Framing
+# ---------------------------------------------------------------------------
+
+
+def write_frame(stream: BinaryIO, payload: bytes) -> None:
+    """Write a length-prefixed frame to a binary stream."""
+    if not isinstance(payload, (bytes, bytearray)):
+        raise TypeError("payload must be bytes")
+    header = f"{len(payload)}\n".encode("ascii")
+    stream.write(header)
+    stream.write(payload)
+    flush = getattr(stream, "flush", None)
+    if flush is not None:
+        flush()
+
+
+def read_frame(stream: BinaryIO) -> bytes | None:
+    """Read a single framed payload from `stream`.
+
+    Returns ``None`` on a clean EOF (no bytes available).  Raises
+    `SandboxException` if the framing is malformed (non-decimal length,
+    negative length, or a truncated payload).
+    """
+    header = bytearray()
+    while True:
+        ch = stream.read(1)
+        if not ch:
+            if not header:
+                return None
+            raise SandboxException(
+                "Truncated frame: EOF reached before length terminator"
+            )
+        if ch == b"\n":
+            break
+        header.extend(ch)
+        if len(header) > 20:  # decimal length can't exceed this many digits
+            raise SandboxException(f"Invalid frame length header: {bytes(header)!r}")
+
+    try:
+        length = int(header.decode("ascii"))
+    except (UnicodeDecodeError, ValueError) as e:
+        raise SandboxException(f"Invalid frame length header: {bytes(header)!r}") from e
+    if length < 0:
+        raise SandboxException(f"Negative frame length: {length}")
+
+    payload = stream.read(length)
+    if len(payload) != length:
+        raise SandboxException(
+            f"Truncated frame: expected {length} bytes, got {len(payload)}"
+        )
+    return bytes(payload)
+
+
+# ---------------------------------------------------------------------------
+# Event
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Event:
+    """A single thing the worker observed while running submitted code.
+
+    Common types:
+      - ``"stdout"`` / ``"stderr"``: ``data`` is a str chunk.
+      - ``"stdin"``: ``data`` is the line consumed by ``input()``.
+      - ``"return"``: ``value`` is the return value (must be JSON-serializable).
+      - ``"figure"``: ``properties`` is a serialized representation of a
+        Matplotlib figure produced by `python_runtime.serialize_figure`.
+
+    Unknown payload fields are preserved as-is so the protocol can grow
+    without breaking older readers.
+    """
+
+    type: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __init__(self, type: str, **payload: Any) -> None:  # noqa: A002
+        self.type = type
+        self.extra = dict(payload)
+
+    # The dataclass-generated __eq__ would compare on `type` and `extra`;
+    # we want to compare on the merged dict so two Events constructed
+    # with the same kwargs in different orders compare equal.
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Event):
+            return NotImplemented
+        return self.type == other.type and self.extra == other.extra
+
+    def __repr__(self) -> str:
+        kw = ", ".join(f"{k}={v!r}" for k, v in self.extra.items())
+        return f"Event(type={self.type!r}{', ' + kw if kw else ''})"
+
+    def to_dict(self) -> dict[str, Any]:
+        out = {"type": self.type}
+        out.update(self.extra)
+        return out
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "Event":
+        d = dict(d)
+        type_ = d.pop("type")
+        return cls(type_, **d)
+
+    # Allow attribute access for documented payload fields used at call sites.
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self.__dict__["extra"][name]
+        except KeyError as e:
+            raise AttributeError(name) from e
+
+
+# ---------------------------------------------------------------------------
+# Request envelope
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Request:
+    runtime: str
+    submission_dir: str
+    module: str
+    obj_name: str
+    args: tuple = ()
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    entries: tuple = ()
+    fixed_time: str | None = None
+    time_limit_seconds: float = 1.0
+    memory_limit_mb: int = 1400
+    log_limit: int = 0
+    captures: tuple = _DEFAULT_CAPTURES
+    protocol_version: int = PROTOCOL_VERSION
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "protocol_version": self.protocol_version,
+                "runtime": self.runtime,
+                "submission_dir": self.submission_dir,
+                "module": self.module,
+                "obj_name": self.obj_name,
+                "args": list(self.args),
+                "kwargs": self.kwargs,
+                "entries": list(self.entries),
+                "fixed_time": self.fixed_time,
+                "time_limit_seconds": self.time_limit_seconds,
+                "memory_limit_mb": self.memory_limit_mb,
+                "log_limit": self.log_limit,
+                "captures": list(self.captures),
+            }
+        )
+
+    @classmethod
+    def from_json(cls, raw: str | bytes) -> "Request":
+        try:
+            d = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise SandboxException(f"Invalid request JSON: {e}") from e
+        version = d.get("protocol_version")
+        if version != PROTOCOL_VERSION:
+            raise SandboxException(
+                f"Unsupported protocol_version {version!r}; expected {PROTOCOL_VERSION}"
+            )
+        required = ("runtime", "submission_dir", "module", "obj_name")
+        for key in required:
+            if key not in d:
+                raise SandboxException(f"Request missing required field: {key!r}")
+        return cls(
+            runtime=d["runtime"],
+            submission_dir=d["submission_dir"],
+            module=d["module"],
+            obj_name=d["obj_name"],
+            args=tuple(d.get("args", ())),
+            kwargs=d.get("kwargs", {}) or {},
+            entries=tuple(d.get("entries", ())),
+            fixed_time=d.get("fixed_time"),
+            time_limit_seconds=d.get("time_limit_seconds", 1.0),
+            memory_limit_mb=d.get("memory_limit_mb", 1400),
+            log_limit=d.get("log_limit", 0),
+            captures=tuple(d.get("captures", _DEFAULT_CAPTURES)),
+        )
+
+
+def write_request(stream: BinaryIO, request: Request) -> None:
+    write_frame(stream, request.to_json().encode("utf-8"))
+
+
+def read_request(stream: BinaryIO) -> Request | None:
+    frame = read_frame(stream)
+    if frame is None:
+        return None
+    return Request.from_json(frame)
+
+
+# ---------------------------------------------------------------------------
+# Response envelope
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Response:
+    events: list[Event] = field(default_factory=list)
+    exception: list[dict[str, Any]] | None = None
+    elapsed_seconds: float = 0.0
+    protocol_version: int = PROTOCOL_VERSION
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "protocol_version": self.protocol_version,
+                "events": [e.to_dict() for e in self.events],
+                "exception": self.exception,
+                "elapsed_seconds": self.elapsed_seconds,
+            }
+        )
+
+    @classmethod
+    def from_json(cls, raw: str | bytes) -> "Response":
+        try:
+            d = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise SandboxException(f"Invalid response JSON: {e}") from e
+        version = d.get("protocol_version")
+        if version != PROTOCOL_VERSION:
+            raise SandboxException(
+                f"Unsupported protocol_version {version!r}; expected {PROTOCOL_VERSION}"
+            )
+        return cls(
+            events=[Event.from_dict(ev) for ev in d.get("events", [])],
+            exception=d.get("exception"),
+            elapsed_seconds=d.get("elapsed_seconds", 0.0),
+        )
+
+
+def write_response(stream: BinaryIO, response: Response) -> None:
+    write_frame(stream, response.to_json().encode("utf-8"))
+
+
+def read_response(stream: BinaryIO) -> Response | None:
+    frame = read_frame(stream)
+    if frame is None:
+        return None
+    return Response.from_json(frame)
+
+
+__all__: Iterable[str] = (
+    "PROTOCOL_VERSION",
+    "Event",
+    "Request",
+    "Response",
+    "SandboxException",
+    "read_frame",
+    "read_request",
+    "read_response",
+    "write_frame",
+    "write_request",
+    "write_response",
+)

--- a/src/generic_grader/sandbox/protocol.py
+++ b/src/generic_grader/sandbox/protocol.py
@@ -175,6 +175,86 @@ class Event:
 
 
 # ---------------------------------------------------------------------------
+# Patch specs
+# ---------------------------------------------------------------------------
+
+
+_VALID_PATCH_KINDS = ("noop", "iter_returns", "raise_error", "source")
+
+
+@dataclass
+class PatchSpec:
+    """A JSON-serializable description of a patch to apply at runtime.
+
+    The worker reconstructs an actual callable from the spec inside the
+    sandbox; the host applies the same spec via `custom_stack` for the
+    Layer 1 (in-process) path.  Keeping the spec format the only thing
+    that crosses the sandbox boundary means we never ship live closures
+    or pickled objects into the worker.
+
+    Kinds
+    -----
+    - ``noop``: replace `target` with a function that ignores all calls.
+    - ``iter_returns``: replace `target` with a function that returns the
+      next value from `values` on each call and raises
+      `ExcessFunctionCallError` once exhausted.
+    - ``raise_error``: replace `target` with a function that raises
+      `error_qualname` on every call.  `error_qualname` is a dotted
+      path resolved at worker startup (e.g.
+      ``generic_grader.utils.exceptions.TurtleDoneError``).
+    - ``source``: define a fresh callable by exec'ing `source` in an
+      empty namespace and pulling out `name`.  This is the escape hatch
+      for assignment-specific patches (e.g. `fake_falling_dist`).
+    """
+
+    target: str
+    kind: str
+    values: list[Any] = field(default_factory=list)
+    error_qualname: str | None = None
+    source: str | None = None
+    name: str | None = None
+    patch_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.kind not in _VALID_PATCH_KINDS:
+            raise SandboxException(
+                f"Unknown PatchSpec kind {self.kind!r}; "
+                f"expected one of {_VALID_PATCH_KINDS}"
+            )
+        if self.kind == "raise_error" and not self.error_qualname:
+            raise SandboxException(
+                "PatchSpec(kind='raise_error') requires error_qualname"
+            )
+        if self.kind == "source" and (not self.source or not self.name):
+            raise SandboxException(
+                "PatchSpec(kind='source') requires both source and name"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "target": self.target,
+            "kind": self.kind,
+            "values": list(self.values),
+            "error_qualname": self.error_qualname,
+            "source": self.source,
+            "name": self.name,
+            "patch_kwargs": dict(self.patch_kwargs),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "PatchSpec":
+        return cls(
+            target=d["target"],
+            kind=d["kind"],
+            values=list(d.get("values", []) or []),
+            error_qualname=d.get("error_qualname"),
+            source=d.get("source"),
+            name=d.get("name"),
+            patch_kwargs=dict(d.get("patch_kwargs", {}) or {}),
+        )
+
+
+# ---------------------------------------------------------------------------
 # Request envelope
 # ---------------------------------------------------------------------------
 
@@ -193,6 +273,7 @@ class Request:
     memory_limit_mb: int = 1400
     log_limit: int = 0
     captures: tuple = _DEFAULT_CAPTURES
+    patch_specs: tuple = ()
     protocol_version: int = PROTOCOL_VERSION
 
     def to_json(self) -> str:
@@ -211,6 +292,7 @@ class Request:
                 "memory_limit_mb": self.memory_limit_mb,
                 "log_limit": self.log_limit,
                 "captures": list(self.captures),
+                "patch_specs": [p.to_dict() for p in self.patch_specs],
             }
         )
 
@@ -242,6 +324,9 @@ class Request:
             memory_limit_mb=d.get("memory_limit_mb", 1400),
             log_limit=d.get("log_limit", 0),
             captures=tuple(d.get("captures", _DEFAULT_CAPTURES)),
+            patch_specs=tuple(
+                PatchSpec.from_dict(p) for p in d.get("patch_specs", []) or []
+            ),
         )
 
 
@@ -310,6 +395,7 @@ def read_response(stream: BinaryIO) -> Response | None:
 __all__: Iterable[str] = (
     "PROTOCOL_VERSION",
     "Event",
+    "PatchSpec",
     "Request",
     "Response",
     "SandboxException",

--- a/src/generic_grader/sandbox/python_runtime.py
+++ b/src/generic_grader/sandbox/python_runtime.py
@@ -35,9 +35,10 @@ import time
 import traceback
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Callable, Iterator
+from unittest.mock import patch as _mock_patch
 
-from generic_grader.sandbox.protocol import Event, Request, Response
+from generic_grader.sandbox.protocol import Event, PatchSpec, Request, Response
 
 # ---------------------------------------------------------------------------
 # Path helpers
@@ -276,6 +277,133 @@ def _import_target(module: str, obj_name: str) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Patch reconstruction
+# ---------------------------------------------------------------------------
+
+# Dotted Python path matching ``module(.sub)*.attribute``.  This is
+# intentionally stricter than the module-name regex above because we
+# need at least one ``.`` to separate the target attribute from its
+# enclosing module.
+_PATCH_TARGET_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+$")
+_ERROR_QUALNAME_RE = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+$"
+)
+
+
+def _target_basename(target: str) -> str:
+    """Return the trailing attribute of a dotted patch target.
+
+    The student-facing error messages built inside the reconstructed
+    mocks only need the short name (e.g. ``"input"`` from
+    ``"submission.input"``), matching the behavior of the host-side
+    :func:`generic_grader.utils.mocks.make_mock_function` helper.
+    """
+    return target.rsplit(".", 1)[-1]
+
+
+def _resolve_error_class(qualname: str) -> type[BaseException]:
+    """Resolve a dotted ``module.Class`` path to an exception class.
+
+    Used by the ``raise_error`` patch kind so the host can ship just
+    the qualified name across the wire instead of a pickled class.
+    """
+    if not _ERROR_QUALNAME_RE.match(qualname):
+        raise ValueError(
+            f"Invalid error_qualname {qualname!r}; expected a dotted Python path."
+        )
+    module_name, _, attr = qualname.rpartition(".")
+    module = importlib.import_module(module_name)
+    cls = getattr(module, attr)
+    if not isinstance(cls, type) or not issubclass(cls, BaseException):
+        raise TypeError(
+            f"{qualname} resolved to {cls!r}, which is not an exception class."
+        )
+    return cls
+
+
+def _build_mock_from_spec(spec: PatchSpec) -> Callable[..., Any]:
+    """Reconstruct the callable described by a :class:`PatchSpec`.
+
+    Each kind maps to one of the host-side mock templates in
+    :mod:`generic_grader.utils.mocks`, but rebuilt locally inside the
+    worker so we never have to ship a live closure across the sandbox
+    boundary.  The fourth kind, ``source``, exec's a host-supplied
+    function source in an empty namespace -- this is the escape hatch
+    used for assignment-specific patches (e.g. a fake physics
+    function).  Running the exec in an empty namespace means the
+    source can't depend on any host-side variables and can't observe
+    the grader's own module globals.
+    """
+    if spec.kind == "noop":
+
+        def _noop(*args: Any, **kwargs: Any) -> None:
+            return None
+
+        return _noop
+
+    if spec.kind == "iter_returns":
+        # Avoid `deepcopy` (used by the host-side helper) because we
+        # already crossed JSON, so each element is a fresh primitive.
+        iterator = iter(list(spec.values))
+        # Import lazily so an unrelated import failure in
+        # generic_grader.utils.exceptions can't break worker startup.
+        from generic_grader.utils.exceptions import ExcessFunctionCallError
+
+        basename = _target_basename(spec.target)
+
+        def _iter_returns(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return next(iterator)
+            except StopIteration as e:
+                raise ExcessFunctionCallError(basename) from e
+
+        return _iter_returns
+
+    if spec.kind == "raise_error":
+        error_cls = _resolve_error_class(spec.error_qualname or "")
+        from generic_grader.utils.docs import make_call_str
+
+        basename = _target_basename(spec.target)
+
+        def _raise(*args: Any, **kwargs: Any) -> Any:
+            call_str = make_call_str(basename, args, kwargs)
+            raise error_cls(f"Your program unexpectedly called `{call_str}`.")
+
+        return _raise
+
+    # spec.kind == "source" (validated in PatchSpec.__post_init__)
+    namespace: dict[str, Any] = {}
+    # The source string was captured with `inspect.getsource` on the
+    # host (already dedented) and is treated here as an isolated
+    # function definition: no access to grader globals, no builtins
+    # mutation, no shared state.
+    exec(compile(spec.source or "", "<patch_spec>", "exec"), namespace)
+    func = namespace.get(spec.name or "")
+    if not callable(func):
+        raise ValueError(
+            f"PatchSpec source did not define a callable named {spec.name!r}."
+        )
+    return func
+
+
+def _enter_patches_from_specs(stack: ExitStack, specs: tuple[PatchSpec, ...]) -> None:
+    """Apply each :class:`PatchSpec` via ``unittest.mock.patch`` on `stack`.
+
+    The patches are reverted automatically when ``stack`` unwinds, so
+    the worker's runtime state is clean by the time we serialize the
+    response.
+    """
+    for spec in specs:
+        if not _PATCH_TARGET_RE.match(spec.target):
+            raise ValueError(
+                f"Invalid patch target {spec.target!r}; expected a dotted path."
+            )
+        mock_fn = _build_mock_from_spec(spec)
+        kwargs = dict(spec.patch_kwargs or {})
+        stack.enter_context(_mock_patch(spec.target, new=mock_fn, **kwargs))
+
+
+# ---------------------------------------------------------------------------
 # fixed_time / freezegun
 # ---------------------------------------------------------------------------
 
@@ -343,19 +471,31 @@ def run_request(request: Request) -> Response:
         builtins.input = responder  # type: ignore[assignment]
         stack.callback(setattr, builtins, "input", original_input)
 
+        # Patches must be active across both the import (so module-level
+        # code that calls the patched target sees the mock) and the
+        # subsequent call.  Any error building/installing patches is
+        # treated like an import-time error so the host sees a
+        # structured exception chain rather than the worker crashing.
         try:
-            target = _import_target(request.module, request.obj_name)
-        except BaseException as e:  # noqa: BLE001 - report any import error
+            _enter_patches_from_specs(stack, tuple(request.patch_specs or ()))
+        except BaseException as e:  # noqa: BLE001 - report patch errors
             exception_chain = _serialize_exception_chain(e)
         else:
-            phase = "call"
             try:
-                returned = target(*tuple(request.args or ()), **(request.kwargs or {}))
-            except BaseException as e:  # noqa: BLE001 - report any student error
+                target = _import_target(request.module, request.obj_name)
+            except BaseException as e:  # noqa: BLE001 - report any import error
                 exception_chain = _serialize_exception_chain(e)
             else:
-                if "return" in captures:
-                    events.append(_make_return_event(returned))
+                phase = "call"
+                try:
+                    returned = target(
+                        *tuple(request.args or ()), **(request.kwargs or {})
+                    )
+                except BaseException as e:  # noqa: BLE001 - report any student error
+                    exception_chain = _serialize_exception_chain(e)
+                else:
+                    if "return" in captures:
+                        events.append(_make_return_event(returned))
 
     # After the patches have been torn down we can safely emit
     # bookkeeping events without polluting the student's stream.

--- a/src/generic_grader/sandbox/python_runtime.py
+++ b/src/generic_grader/sandbox/python_runtime.py
@@ -491,6 +491,17 @@ def run_request(request: Request) -> Response:
     phase = "import"
     start = time.perf_counter()
 
+    # Cheap unconditional checkpoint log -- one ``perf_counter`` call
+    # per major phase.  The host's profile writer (see ``runner.py``,
+    # ``GENERIC_GRADER_PROFILE``) merges this list into its JSON line
+    # when profiling is enabled, and ignores it otherwise.  Keeping
+    # the worker side unconditional means the host doesn't have to
+    # propagate an env var across the sandbox boundary.
+    checkpoints: list[tuple[str, float]] = [("enter", 0.0)]
+
+    def _checkpoint(name: str) -> None:
+        checkpoints.append((name, time.perf_counter() - start))
+
     def _push_phase(name: str) -> None:
         events.append(Event(type="phase", name=name))
 
@@ -531,11 +542,13 @@ def run_request(request: Request) -> Response:
         except BaseException as e:  # noqa: BLE001 - report patch errors
             exception_chain = _serialize_exception_chain(e)
         else:
+            _checkpoint("patches_installed")
             try:
                 target = _import_target(request.module, request.obj_name)
             except BaseException as e:  # noqa: BLE001 - report any import error
                 exception_chain = _serialize_exception_chain(e)
             else:
+                _checkpoint("import_target")
                 phase = "call"
                 try:
                     # ``Request.time_limit_seconds`` is the student-code
@@ -554,6 +567,7 @@ def run_request(request: Request) -> Response:
                 else:
                     if "return" in captures:
                         events.append(_make_return_event(returned))
+                _checkpoint("call_returned")
 
     # After the patches have been torn down we can safely emit
     # bookkeeping events without polluting the student's stream.
@@ -568,6 +582,7 @@ def run_request(request: Request) -> Response:
     # them on the host side. We always close figures afterwards so the
     # next in-process run starts clean -- the isolate runner spawns a
     # fresh worker per test, but unit tests reuse this process.
+    _checkpoint("figures_start")
     if "figures" in captures:
         try:
             # Imported lazily so non-plot tests don't pay the matplotlib
@@ -590,7 +605,10 @@ def run_request(request: Request) -> Response:
         except ImportError:
             pass
 
+    _checkpoint("figures_done")
     _push_phase(phase)
+    _checkpoint("completed")
+    events.append(Event(type="profile", checkpoints=checkpoints))
 
     elapsed = time.perf_counter() - start
     return Response(events=events, exception=exception_chain, elapsed_seconds=elapsed)

--- a/src/generic_grader/sandbox/python_runtime.py
+++ b/src/generic_grader/sandbox/python_runtime.py
@@ -322,6 +322,32 @@ def run_request(request: Request) -> Response:
         if leftover:
             events.append(Event(type="unused_entries", count=len(leftover)))
 
+    # Serialize any open matplotlib figures so plot tests can inspect
+    # them on the host side. We always close figures afterwards so the
+    # next in-process run starts clean -- the isolate runner spawns a
+    # fresh worker per test, but unit tests reuse this process.
+    if "figures" in captures:
+        try:
+            # Imported lazily so non-plot tests don't pay the matplotlib
+            # startup cost and runtimes without matplotlib still work.
+            from generic_grader.sandbox.figure_serializer import (
+                serialize_current_figures,
+            )
+
+            for fig_dict in serialize_current_figures():
+                events.append(Event(type="figure", properties=fig_dict))
+        except ImportError:
+            pass
+    else:
+        # Even when figures aren't captured, close any open figures
+        # so they don't leak into the next call.
+        try:
+            import matplotlib.pyplot as _plt
+
+            _plt.close("all")
+        except ImportError:
+            pass
+
     _push_phase(phase)
 
     elapsed = time.perf_counter() - start

--- a/src/generic_grader/sandbox/python_runtime.py
+++ b/src/generic_grader/sandbox/python_runtime.py
@@ -29,6 +29,7 @@ import importlib
 import io
 import json
 import os
+import re
 import sys
 import time
 import traceback
@@ -129,8 +130,11 @@ class _Responder:
             self._stdout.write(str(prompt))
         try:
             entry = next(self._entries)
-        except StopIteration as e:
-            raise EOFError("EOF when reading a line") from e
+        except StopIteration:
+            # Match CPython's real ``input()`` semantics, which raise a
+            # bare EOFError when stdin is exhausted with no chained
+            # ``StopIteration`` polluting the visible cause chain.
+            raise EOFError("EOF when reading a line") from None
         entry = str(entry)
         self._events.append(Event(type="stdin", data=entry))
         self.consumed += 1
@@ -171,6 +175,9 @@ def _serialize_traceback(tb_summary: traceback.StackSummary) -> str:
     return "".join(traceback.StackSummary.from_list(student_frames).format())
 
 
+_MAX_EXCEPTION_CHAIN_LINKS = 20
+
+
 def _serialize_exception_chain(exc: BaseException) -> list[dict[str, Any]]:
     """Walk an exception's cause/context chain and return a serialized list.
 
@@ -180,11 +187,21 @@ def _serialize_exception_chain(exc: BaseException) -> list[dict[str, Any]]:
     * ``type``: the exception class's qualified name.
     * ``message``: ``str(exc)``.
     * ``traceback``: the formatted traceback, filtered to student frames.
+
+    Cycle protection uses both an ``id()`` set and a hard depth cap
+    (``_MAX_EXCEPTION_CHAIN_LINKS``).  In practice the chain is kept
+    alive by ``current`` so ``id()`` reuse is impossible inside the
+    loop, but the depth cap is a cheap belt-and-suspenders guard
+    against pathological user-constructed cycles.
     """
     chain: list[dict[str, Any]] = []
     seen: set[int] = set()
     current: BaseException | None = exc
-    while current is not None and id(current) not in seen:
+    while (
+        current is not None
+        and id(current) not in seen
+        and len(chain) < _MAX_EXCEPTION_CHAIN_LINKS
+    ):
         seen.add(id(current))
         tb_summary = traceback.extract_tb(current.__traceback__)
         chain.append(
@@ -194,7 +211,14 @@ def _serialize_exception_chain(exc: BaseException) -> list[dict[str, Any]]:
                 "traceback": _serialize_traceback(tb_summary),
             }
         )
-        current = current.__cause__ or current.__context__
+        # Walk the chain the same way CPython's traceback printer does:
+        # ``__cause__`` always wins, otherwise ``__context__`` --
+        # unless ``__suppress_context__`` is set (which is what
+        # ``raise X from None`` does to hide an implicit context).
+        next_exc = current.__cause__
+        if next_exc is None and not current.__suppress_context__:
+            next_exc = current.__context__
+        current = next_exc
     return chain
 
 
@@ -225,8 +249,28 @@ def _patched_cwd_and_path(submission_dir: str):
             pass
 
 
+# Dotted Python identifier, e.g. ``submission`` or ``pkg.submission``.
+_MODULE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$")
+_OBJ_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
 def _import_target(module: str, obj_name: str) -> Any:
-    """Import `module` and return its `obj_name` attribute."""
+    """Import `module` and return its `obj_name` attribute.
+
+    Raises ``ValueError`` if either name fails the Python-identifier
+    syntax check.  Defense in depth: the host always sets these from
+    `Options` (which themselves come from grader code), but the worker
+    is also reached directly in tests and we don't want a malformed
+    request to feed arbitrary input into ``importlib.import_module``.
+    """
+    if not _MODULE_NAME_RE.match(module):
+        raise ValueError(
+            f"Invalid module name {module!r}; expected a dotted Python identifier."
+        )
+    if not _OBJ_NAME_RE.match(obj_name):
+        raise ValueError(
+            f"Invalid object name {obj_name!r}; expected a Python identifier."
+        )
     mod = importlib.import_module(module)
     return getattr(mod, obj_name)
 

--- a/src/generic_grader/sandbox/python_runtime.py
+++ b/src/generic_grader/sandbox/python_runtime.py
@@ -1,0 +1,331 @@
+"""Python runtime worker for the sandboxed grader.
+
+Responsibilities
+----------------
+
+* Resolve `Request.module:Request.obj_name` from `Request.submission_dir`.
+* Patch ``sys.stdout`` / ``sys.stderr`` to emit framed `Event` records.
+* Patch ``builtins.input`` to pull from a queue of simulated entries,
+  emitting one ``stdin`` event per consumed entry.
+* Call the resolved object and emit a ``return`` event with the
+  result (or, for non-JSON-serializable returns, a ``repr`` flagged event).
+* If anything raises (during import or during the call), walk the
+  ``__cause__`` / ``__context__`` chain, build a structured list of
+  ``{type, message, traceback}`` dicts, and stash it on the response.
+* Filter traceback frames to files inside ``submission_dir`` so the
+  worker never reveals grader internals to the student.
+
+The worker does **not** perform sandbox isolation itself — that is the
+job of the runner in `runner.py` (commit 4), which spawns the worker
+under ``isolate``.  This module is in-process so it can be unit
+tested directly and so the same code runs both at test time and
+inside the real sandbox.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import io
+import json
+import os
+import sys
+import time
+import traceback
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from generic_grader.sandbox.protocol import Event, Request, Response
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+# Frames whose filename resolves under any of these roots are considered
+# "grader frames" and stripped from serialized tracebacks before they
+# cross the wire.  We compute these once at import time.
+_GRADER_ROOTS: tuple[str, ...] = tuple(
+    sorted(
+        {
+            str(Path(__file__).resolve().parent.parent),
+        }
+    )
+)
+
+
+def _is_grader_frame(frame_filename: str) -> bool:
+    """Return True if `frame_filename` is inside the grader's own source."""
+    if not frame_filename:
+        return False
+    try:
+        resolved = str(Path(frame_filename).resolve())
+    except (OSError, ValueError):
+        resolved = frame_filename
+    return any(resolved.startswith(root) for root in _GRADER_ROOTS)
+
+
+# ---------------------------------------------------------------------------
+# Stream wrappers
+# ---------------------------------------------------------------------------
+
+
+class _EventStream(io.TextIOBase):
+    """A text stream that funnels every write into an event sink.
+
+    Each `write` call appends an Event of the configured type to the
+    shared `events` list.  Empty writes are dropped so that
+    ``print("x")`` (which writes ``"x"`` and ``"\\n"`` separately on
+    some Python versions) doesn't produce zero-length events.
+    """
+
+    def __init__(self, events: list[Event], event_type: str) -> None:
+        super().__init__()
+        self._events = events
+        self._event_type = event_type
+
+    # TextIOBase already provides a `flush` no-op, which is what we want.
+
+    def writable(self) -> bool:  # pragma: no cover - trivial
+        return True
+
+    def write(self, s: str) -> int:
+        if s:
+            self._events.append(Event(type=self._event_type, data=s))
+        return len(s)
+
+
+# ---------------------------------------------------------------------------
+# input() replacement
+# ---------------------------------------------------------------------------
+
+
+class _Responder:
+    """Callable that mimics the builtin ``input`` against an entries queue.
+
+    * Each call writes the prompt to the stdout sink (preserving the
+      ``print("prompt", end="")`` behavior of the real input).
+    * Each call emits a `stdin` event with the consumed entry.
+    * Running out of entries raises `EOFError` (the same exception
+      Python raises on EOF in real `input()`), letting host code
+      classify the failure.
+    """
+
+    def __init__(
+        self,
+        events: list[Event],
+        entries: Iterator[str],
+        stdout_sink: _EventStream | None,
+    ) -> None:
+        self._events = events
+        self._entries = entries
+        self._stdout = stdout_sink
+        self.consumed = 0
+
+    def __call__(self, prompt: str = "") -> str:
+        # Echo the prompt through whatever the current stdout is so the
+        # event log mirrors real terminal interaction.
+        if prompt and self._stdout is not None:
+            self._stdout.write(str(prompt))
+        try:
+            entry = next(self._entries)
+        except StopIteration as e:
+            raise EOFError("EOF when reading a line") from e
+        entry = str(entry)
+        self._events.append(Event(type="stdin", data=entry))
+        self.consumed += 1
+        return entry
+
+
+# ---------------------------------------------------------------------------
+# Return-value serialization
+# ---------------------------------------------------------------------------
+
+
+def _make_return_event(value: Any) -> Event:
+    """Build a `return` event whose payload is safe to JSON-serialize.
+
+    JSON-safe values are passed through verbatim. Anything else is
+    rendered via ``repr()`` with a ``non_serializable`` flag so the
+    host can distinguish the two cases.
+    """
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return Event(type="return", non_serializable=True, repr=repr(value))
+    return Event(type="return", value=value)
+
+
+# ---------------------------------------------------------------------------
+# Exception serialization
+# ---------------------------------------------------------------------------
+
+
+def _serialize_traceback(tb_summary: traceback.StackSummary) -> str:
+    """Render a StackSummary as text, dropping any grader frames."""
+    student_frames = [f for f in tb_summary if not _is_grader_frame(f.filename)]
+    if not student_frames:
+        # Nothing to show without exposing grader internals; keep the
+        # student aware that frames were elided rather than leaking them.
+        return "  (no student frames in traceback)\n"
+    return "".join(traceback.StackSummary.from_list(student_frames).format())
+
+
+def _serialize_exception_chain(exc: BaseException) -> list[dict[str, Any]]:
+    """Walk an exception's cause/context chain and return a serialized list.
+
+    The list is ordered from outermost (the exception actually raised)
+    to innermost (its root cause).  Each entry carries:
+
+    * ``type``: the exception class's qualified name.
+    * ``message``: ``str(exc)``.
+    * ``traceback``: the formatted traceback, filtered to student frames.
+    """
+    chain: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        tb_summary = traceback.extract_tb(current.__traceback__)
+        chain.append(
+            {
+                "type": type(current).__name__,
+                "message": str(current),
+                "traceback": _serialize_traceback(tb_summary),
+            }
+        )
+        current = current.__cause__ or current.__context__
+    return chain
+
+
+# ---------------------------------------------------------------------------
+# Module loading
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _patched_cwd_and_path(submission_dir: str):
+    """Run a block with cwd and sys.path pointing at the submission dir."""
+    original_cwd = os.getcwd()
+    original_path = list(sys.path)
+    original_modules = set(sys.modules)
+    try:
+        os.chdir(submission_dir)
+        sys.path.insert(0, submission_dir)
+        yield
+    finally:
+        # Remove anything imported during the run so a subsequent call
+        # with a different submission_dir doesn't get the cached module.
+        for name in set(sys.modules) - original_modules:
+            sys.modules.pop(name, None)
+        sys.path[:] = original_path
+        try:
+            os.chdir(original_cwd)
+        except OSError:  # pragma: no cover - host cwd vanished
+            pass
+
+
+def _import_target(module: str, obj_name: str) -> Any:
+    """Import `module` and return its `obj_name` attribute."""
+    mod = importlib.import_module(module)
+    return getattr(mod, obj_name)
+
+
+# ---------------------------------------------------------------------------
+# fixed_time / freezegun
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _maybe_freeze_time(fixed_time: str | None):
+    if not fixed_time:
+        yield
+        return
+    # Imported lazily so the worker can run in environments where
+    # freezegun is unavailable (e.g. minimal Octave installs later).
+    from freezegun import freeze_time
+
+    with freeze_time(fixed_time):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def run_request(request: Request) -> Response:
+    """Run a single `Request` and return a `Response`.
+
+    This function is the worker's only public API.  It is intentionally
+    synchronous and pure (no daemon thread, no global state mutation
+    beyond the patches it explicitly applies and reverts) so the
+    isolate runner can simply ``read_request(stdin) -> run_request ->
+    write_response(stdout)`` and exit.
+    """
+    captures = set(request.captures or ())
+    events: list[Event] = []
+    exception_chain: list[dict[str, Any]] | None = None
+    phase = "import"
+    start = time.perf_counter()
+
+    def _push_phase(name: str) -> None:
+        events.append(Event(type="phase", name=name))
+
+    # Pre-compose stream sinks so the input responder can echo prompts
+    # into the same stdout the student would write to.
+    stdout_sink = _EventStream(events, "stdout") if "stdout" in captures else None
+    stderr_sink = _EventStream(events, "stderr") if "stderr" in captures else None
+
+    entries_iter: Iterator[str] = iter(request.entries or ())
+    responder = _Responder(events, entries_iter, stdout_sink)
+
+    with ExitStack() as stack:
+        stack.enter_context(_patched_cwd_and_path(request.submission_dir))
+        stack.enter_context(_maybe_freeze_time(request.fixed_time))
+
+        # Patch stdout / stderr / input via plain attribute swap (cheaper
+        # and more deterministic than unittest.mock.patch in-process).
+        if stdout_sink is not None:
+            original_stdout = sys.stdout
+            sys.stdout = stdout_sink  # type: ignore[assignment]
+            stack.callback(setattr, sys, "stdout", original_stdout)
+        if stderr_sink is not None:
+            original_stderr = sys.stderr
+            sys.stderr = stderr_sink  # type: ignore[assignment]
+            stack.callback(setattr, sys, "stderr", original_stderr)
+
+        original_input = builtins.input
+        builtins.input = responder  # type: ignore[assignment]
+        stack.callback(setattr, builtins, "input", original_input)
+
+        try:
+            target = _import_target(request.module, request.obj_name)
+        except BaseException as e:  # noqa: BLE001 - report any import error
+            exception_chain = _serialize_exception_chain(e)
+        else:
+            phase = "call"
+            try:
+                returned = target(*tuple(request.args or ()), **(request.kwargs or {}))
+            except BaseException as e:  # noqa: BLE001 - report any student error
+                exception_chain = _serialize_exception_chain(e)
+            else:
+                if "return" in captures:
+                    events.append(_make_return_event(returned))
+
+    # After the patches have been torn down we can safely emit
+    # bookkeeping events without polluting the student's stream.
+    if exception_chain is None:
+        phase = "completed"
+        # Count any entries the student didn't consume.
+        leftover = list(entries_iter)
+        if leftover:
+            events.append(Event(type="unused_entries", count=len(leftover)))
+
+    _push_phase(phase)
+
+    elapsed = time.perf_counter() - start
+    return Response(events=events, exception=exception_chain, elapsed_seconds=elapsed)
+
+
+__all__ = ("run_request",)

--- a/src/generic_grader/sandbox/python_runtime.py
+++ b/src/generic_grader/sandbox/python_runtime.py
@@ -30,6 +30,7 @@ import io
 import json
 import os
 import re
+import signal
 import sys
 import time
 import traceback
@@ -421,6 +422,55 @@ def _maybe_freeze_time(fixed_time: str | None):
         yield
 
 
+@contextmanager
+def _student_call_time_limit(seconds: float):
+    """Wrap the student call in a ``SIGALRM`` alarm matching legacy semantics.
+
+    The legacy non-sandbox path (`generic_grader.utils.resource_limits.
+    time_limit`) wraps *only* the student's call in a ``signal.alarm``,
+    not interpreter startup or grader-side imports.  We mirror that
+    here so ``Request.time_limit_seconds`` keeps its original meaning:
+    the budget for student code, with interpreter / import cost free.
+
+    Isolate's outer ``--time`` limit still applies as a hard safety
+    net (set by the runner to ``time_limit + STARTUP_OVERHEAD_SECONDS``),
+    so genuinely runaway processes are still killed -- they just get
+    a structured ``UserTimeoutError`` first when their student code
+    overruns its budget.
+
+    Uses ``signal.setitimer`` (not ``signal.alarm``) so fractional
+    budgets work; ``signal.alarm`` would silently truncate ``0.5``
+    seconds to ``0`` (disabling the alarm).
+
+    A non-positive ``seconds`` value disables the alarm entirely.
+    """
+    if seconds <= 0:
+        yield
+        return
+
+    # Imported lazily so non-sandbox code paths that re-import this
+    # module (e.g. unit tests) don't pull in the full grader package
+    # just to exercise the worker dispatch.
+    from generic_grader.utils.exceptions import UserTimeoutError
+
+    def _handler(signum, frame):  # pragma: no cover - exercised via signal
+        raise UserTimeoutError(
+            f"The time limit for this test is {seconds:g}"
+            + (" second." if seconds == 1 else " seconds.")
+        )
+
+    previous = signal.signal(signal.SIGALRM, _handler)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        # Cancel any pending alarm and restore the previous handler
+        # so a leftover timer can't fire later (e.g. during figure
+        # serialization on the way out of ``run_request``).
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
+
+
 # ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
@@ -488,9 +538,17 @@ def run_request(request: Request) -> Response:
             else:
                 phase = "call"
                 try:
-                    returned = target(
-                        *tuple(request.args or ()), **(request.kwargs or {})
-                    )
+                    # ``Request.time_limit_seconds`` is the student-code
+                    # budget (legacy ``Options.time_limit`` semantics).
+                    # Isolate's outer ``--time`` flag is a wider safety
+                    # net; this alarm matches the legacy non-sandbox
+                    # ``resource_limits.time_limit`` behavior so timed
+                    # tests look the same to assignments regardless
+                    # of which runtime path executes them.
+                    with _student_call_time_limit(request.time_limit_seconds):
+                        returned = target(
+                            *tuple(request.args or ()), **(request.kwargs or {})
+                        )
                 except BaseException as e:  # noqa: BLE001 - report any student error
                     exception_chain = _serialize_exception_chain(e)
                 else:

--- a/src/generic_grader/sandbox/runner.py
+++ b/src/generic_grader/sandbox/runner.py
@@ -1,0 +1,452 @@
+"""Host-side runner that drives a sandboxed worker via ``isolate``.
+
+The grader process (the host) calls `IsolateRunner.run(request)` for
+each test.  The runner:
+
+1. Allocates a free box via ``isolate --box-id N --init`` (and
+   ``--cleanup`` after).
+2. Builds the ``--run`` invocation with bind mounts, resource limits,
+   and a meta file for post-mortem classification.
+3. Spawns the child, writes the request frame to its stdin, reads
+   the response frame from its stdout.
+4. Parses the meta file to classify any abnormal exit (timeout,
+   memory, signal, runtime error) and folds it back into the
+   `Response.exception` so callers always get a uniform structure.
+
+The class is split into two layers:
+
+* `build_run_argv()` is a pure function that returns the argv list
+  for the ``--run`` invocation.  It is the part that holds all the
+  isolate CLI knowledge and so it gets the densest unit-test coverage.
+* `IsolateRunner.run()` orchestrates init / spawn / parse / cleanup
+  with everything that *isn't* command construction.  It accepts an
+  injectable ``subprocess_runner`` so the unit tests can stub real
+  ``isolate`` calls without needing the privileged binary installed.
+
+This makes the runner exercisable in CI environments that don't have
+``isolate`` while still letting us run an integration test against a
+real install when one is available.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from typing import Callable, Sequence
+
+from generic_grader.sandbox.protocol import (
+    Request,
+    Response,
+    SandboxException,
+    read_response,
+    write_request,
+)
+
+DEFAULT_BOX_ID = 0
+DEFAULT_WALL_TIME_MULTIPLIER = 2.0
+DEFAULT_PROCESSES = 64
+DEFAULT_FSIZE_KB = 65536  # 64 MB of file writes per test
+
+
+# ---------------------------------------------------------------------------
+# Command construction
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunPlan:
+    """A fully-resolved description of one isolate run.
+
+    Construction is pure: no filesystem mutation, no subprocess calls.
+    Tests build a `RunPlan` and assert on its argv.
+    """
+
+    box_id: int
+    submission_dir: str
+    grader_src: str
+    python_executable: str
+    meta_path: str
+    time_limit_seconds: float
+    wall_time_limit_seconds: float
+    memory_limit_mb: int
+    processes: int
+    fsize_kb: int
+    extra_dirs: tuple[tuple[str, str, str], ...] = field(default_factory=tuple)
+    isolate_binary: str = "isolate"
+
+    def init_argv(self) -> list[str]:
+        return [self.isolate_binary, "--box-id", str(self.box_id), "--init"]
+
+    def cleanup_argv(self) -> list[str]:
+        return [self.isolate_binary, "--box-id", str(self.box_id), "--cleanup"]
+
+    def run_argv(self) -> list[str]:
+        argv: list[str] = [
+            self.isolate_binary,
+            "--box-id",
+            str(self.box_id),
+            "--meta",
+            self.meta_path,
+            "--time",
+            f"{self.time_limit_seconds:.3f}",
+            "--wall-time",
+            f"{self.wall_time_limit_seconds:.3f}",
+            "--mem",
+            str(self.memory_limit_mb * 1024),  # isolate expects KB
+            "--processes",
+            str(self.processes),
+            "--fsize",
+            str(self.fsize_kb),
+            # /box/submission is the worker's CWD and is writable.
+            "--dir",
+            f"/box/submission={self.submission_dir}:rw",
+            # /box/grader is the generic_grader install, read only.
+            "--dir",
+            f"/box/grader={self.grader_src}",
+            # Set PYTHONPATH and a sane cwd.
+            "--env",
+            "PYTHONPATH=/box/grader",
+            "--env",
+            "MPLBACKEND=Agg",
+            "--env",
+            "HOME=/box/submission",
+            "--chdir",
+            "/box/submission",
+            # Default isolate already disables network; pass --share-net
+            # is what enables it, so we deliberately omit that flag.
+        ]
+        for name, source, opts in self.extra_dirs:
+            spec = f"/box/{name}={source}"
+            if opts:
+                spec = f"{spec}:{opts}"
+            argv.extend(["--dir", spec])
+        argv.extend(
+            [
+                "--run",
+                "--",
+                self.python_executable,
+                "-I",
+                "-S",
+                "-m",
+                "generic_grader.sandbox.worker_main",
+            ]
+        )
+        return argv
+
+
+def build_run_plan(
+    request: Request,
+    *,
+    box_id: int,
+    grader_src: str,
+    meta_path: str,
+    python_executable: str | None = None,
+    isolate_binary: str = "isolate",
+    extra_dirs: Sequence[tuple[str, str, str]] = (),
+) -> RunPlan:
+    """Construct a :class:`RunPlan` from a :class:`Request`.
+
+    Resource limits come straight from the request -- `Request`
+    already supplies sensible defaults (1s, 1400 MB) so the runner
+    doesn't need to layer its own.  Tests that need a different
+    limit override it on the request.
+    """
+    time_limit = request.time_limit_seconds
+    wall_limit = time_limit * DEFAULT_WALL_TIME_MULTIPLIER
+    mem_mb = request.memory_limit_mb
+    python_exe = python_executable or sys.executable
+    return RunPlan(
+        box_id=box_id,
+        submission_dir=request.submission_dir,
+        grader_src=grader_src,
+        python_executable=python_exe,
+        meta_path=meta_path,
+        time_limit_seconds=time_limit,
+        wall_time_limit_seconds=wall_limit,
+        memory_limit_mb=mem_mb,
+        processes=DEFAULT_PROCESSES,
+        fsize_kb=DEFAULT_FSIZE_KB,
+        extra_dirs=tuple(extra_dirs),
+        isolate_binary=isolate_binary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Meta-file parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_meta(meta_text: str) -> dict[str, str]:
+    """Parse the `key:value` lines isolate writes to its meta file."""
+    out: dict[str, str] = {}
+    for raw in meta_text.splitlines():
+        line = raw.strip()
+        if not line or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        out[key.strip()] = value.strip()
+    return out
+
+
+def classify_meta(meta: dict[str, str]) -> dict[str, str] | None:
+    """Map isolate's meta file to a structured exception entry.
+
+    Returns ``None`` when the run looks clean (no status code, exit
+    code 0), otherwise a dict matching the exception-chain shape used
+    elsewhere in the protocol.
+    """
+    status = meta.get("status")
+    if status:
+        if status == "TO":
+            return {
+                "type": "SandboxTimeout",
+                "message": meta.get("message", "Wall-time or CPU-time limit exceeded."),
+                "traceback": "",
+            }
+        if status == "ML":
+            return {
+                "type": "SandboxMemoryLimit",
+                "message": meta.get("message", "Memory limit exceeded."),
+                "traceback": "",
+            }
+        if status == "SG":
+            return {
+                "type": "SandboxSignal",
+                "message": meta.get(
+                    "message", f"Killed by signal {meta.get('exitsig', '?')}."
+                ),
+                "traceback": "",
+            }
+        if status == "XX":
+            return {
+                "type": "SandboxInternalError",
+                "message": meta.get("message", "Sandbox internal error."),
+                "traceback": "",
+            }
+        # Anything else (e.g. "RE" runtime error) is the worker exiting
+        # nonzero -- the worker itself reports its exception in the
+        # response payload, so we only synthesize one here if the
+        # exit code is set and nonzero. The caller decides what to
+        # do based on whether a response frame was read.
+        return {
+            "type": "SandboxAbnormalExit",
+            "message": meta.get(
+                "message",
+                f"Worker exited with status={status} exitcode={meta.get('exitcode', '?')}.",
+            ),
+            "traceback": "",
+        }
+    exitcode = meta.get("exitcode", "0")
+    if exitcode and exitcode != "0":
+        return {
+            "type": "SandboxAbnormalExit",
+            "message": f"Worker exited with exitcode={exitcode}.",
+            "traceback": "",
+        }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Subprocess hook
+# ---------------------------------------------------------------------------
+
+
+SubprocessRunner = Callable[..., subprocess.CompletedProcess]
+
+
+def _default_subprocess_runner(*args, **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IsolateRunner:
+    """High-level runner that drives a single sandboxed worker call."""
+
+    grader_src: str
+    isolate_binary: str = "isolate"
+    box_id: int = DEFAULT_BOX_ID
+    python_executable: str | None = None
+    subprocess_runner: SubprocessRunner = _default_subprocess_runner
+    extra_dirs: Sequence[tuple[str, str, str]] = ()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(self, request: Request) -> Response:
+        """Run `request` through a fresh sandboxed worker and return its `Response`."""
+        if not shutil.which(self.isolate_binary):
+            raise SandboxException(
+                f"isolate binary not found at {self.isolate_binary!r}. "
+                "Install isolate (e.g. `apt install isolate`) and run "
+                "`sudo isolate --init` once before grading."
+            )
+
+        meta_fd, meta_path = tempfile.mkstemp(prefix="isolate-meta-", suffix=".txt")
+        os.close(meta_fd)
+        try:
+            plan = build_run_plan(
+                request,
+                box_id=self.box_id,
+                grader_src=self.grader_src,
+                meta_path=meta_path,
+                python_executable=self.python_executable,
+                isolate_binary=self.isolate_binary,
+                extra_dirs=self.extra_dirs,
+            )
+
+            init = self.subprocess_runner(
+                plan.init_argv(),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if init.returncode != 0:
+                raise SandboxException(
+                    f"`isolate --init` failed for box_id={self.box_id}: "
+                    f"{init.stderr.strip() or init.stdout.strip()}"
+                )
+
+            try:
+                stdin_bytes = _encode_request(request)
+                completed = self.subprocess_runner(
+                    plan.run_argv(),
+                    input=stdin_bytes,
+                    capture_output=True,
+                    check=False,
+                )
+                response = _decode_response_or_raise(
+                    completed.stdout,
+                    completed.stderr,
+                    completed.returncode,
+                    meta_path,
+                )
+            finally:
+                self.subprocess_runner(
+                    plan.cleanup_argv(),
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+        finally:
+            try:
+                os.unlink(meta_path)
+            except OSError:  # pragma: no cover - best effort
+                pass
+
+        return response
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _encode_request(request: Request) -> bytes:
+    """Serialize a request to the framed wire format as bytes."""
+    import io
+
+    buf = io.BytesIO()
+    write_request(buf, request)
+    return buf.getvalue()
+
+
+def _decode_response_or_raise(
+    stdout_bytes: bytes,
+    stderr_bytes: bytes,
+    exit_code: int,
+    meta_path: str,
+) -> Response:
+    """Decode the worker's response or synthesize one from the meta file.
+
+    The runner has three kinds of outcomes:
+
+    1. The worker wrote a complete frame -> decode and return it.
+       If the meta file shows a sandbox-level abnormal exit (e.g. the
+       runner killed the worker after it finished its frame), we
+       still trust the worker's frame -- the host can layer additional
+       diagnostics on top via the meta info if it wants.
+
+    2. The worker wrote nothing (or a partial frame) -> the sandbox
+       killed it before it could respond.  We synthesize a `Response`
+       carrying the classified meta exception.
+
+    3. The worker exited nonzero with no frame and no meta diagnostic
+       -> last-resort generic failure with stderr included so the
+       student can see Python's complaint about a missing module
+       etc.
+    """
+    import io
+
+    meta_text = ""
+    try:
+        with open(meta_path, encoding="utf-8") as f:
+            meta_text = f.read()
+    except OSError:
+        meta_text = ""
+    meta = parse_meta(meta_text)
+    classified = classify_meta(meta)
+
+    if stdout_bytes:
+        try:
+            return read_response(io.BytesIO(stdout_bytes))
+        except SandboxException:
+            # Partial frame or junk: fall through to the synthetic path.
+            pass
+
+    # No frame -- build one from the meta classification.
+    if classified is None:
+        # No meta classification either; build a generic failure that
+        # includes whatever the worker wrote to stderr.
+        stderr_text = _decode_text(stderr_bytes)
+        classified = {
+            "type": "SandboxAbnormalExit",
+            "message": (
+                f"Worker exited with code {exit_code} and no response frame. "
+                + (f"stderr: {stderr_text}" if stderr_text else "")
+            ).strip(),
+            "traceback": "",
+        }
+
+    return Response(
+        events=[],
+        exception=[classified],
+        elapsed_seconds=_meta_time(meta),
+    )
+
+
+def _decode_text(buf: bytes) -> str:
+    try:
+        return buf.decode("utf-8", errors="replace").strip()
+    except Exception:  # pragma: no cover - utf-8 with errors='replace' can't raise
+        return ""
+
+
+def _meta_time(meta: dict[str, str]) -> float:
+    """Best-effort elapsed time from isolate's meta file (wall-time or time)."""
+    for key in ("time-wall", "time"):
+        if key in meta:
+            try:
+                return float(meta[key])
+            except (TypeError, ValueError):
+                continue
+    return 0.0
+
+
+__all__ = (
+    "DEFAULT_BOX_ID",
+    "IsolateRunner",
+    "RunPlan",
+    "build_run_plan",
+    "classify_meta",
+    "parse_meta",
+)

--- a/src/generic_grader/sandbox/runner.py
+++ b/src/generic_grader/sandbox/runner.py
@@ -52,6 +52,16 @@ DEFAULT_WALL_TIME_MULTIPLIER = 2.0
 DEFAULT_PROCESSES = 64
 DEFAULT_FSIZE_KB = 65536  # 64 MB of file writes per test
 
+# isolate bind-mounts the following host paths by default (see
+# ``init_dir_rules`` in upstream ``rules.c``).  When the Python
+# executable we want to run lives outside *all* of these roots --
+# typical under ``uv``, ``pyenv``, ``conda``, or any venv outside
+# ``/usr`` -- the chroot can't see it and ``execve`` fails with
+# ``No such file or directory`` (exit 127).  In that case the
+# runner has to add an extra ``--dir`` rule to expose the python
+# prefix.
+_ISOLATE_DEFAULT_MOUNT_ROOTS = ("/bin", "/dev", "/lib", "/lib64", "/proc", "/usr")
+
 # The host-side submission directory is bind-mounted at this path
 # inside the sandbox (see ``RunPlan.run_argv``).  The worker's CWD is
 # also set to this path.  We rewrite ``Request.submission_dir`` to
@@ -187,6 +197,50 @@ class RunPlan:
         return argv
 
 
+def _python_prefix_mount(python_exe: str) -> tuple[str, str, str] | None:
+    """Return an ``extra_dirs`` entry exposing ``python_exe`` in the sandbox.
+
+    isolate's default ``--dir`` rules cover ``/bin``, ``/lib``,
+    ``/lib64``, and ``/usr``.  A Python interpreter installed by
+    ``uv``, ``pyenv``, ``conda``, or any virtualenv outside ``/usr``
+    is *not* visible in the chroot, so ``execve`` of that path fails
+    with ``No such file or directory`` (exit 127).
+
+    To make such an interpreter reachable we bind-mount its prefix
+    (e.g. ``~/.local/share/uv/python/cpython-3.12.X-...``) into the
+    sandbox at the *same* host path.  Binding at the original path
+    means the absolute ``python_executable`` argv string we already
+    pass to ``--run`` resolves correctly inside the chroot, without
+    any path rewriting.
+
+    Returns ``None`` if the executable is already inside one of
+    isolate's default mount roots and no extra mount is needed.
+    """
+    real_exe = os.path.realpath(python_exe)
+    for root in _ISOLATE_DEFAULT_MOUNT_ROOTS:
+        if real_exe == root or real_exe.startswith(root + os.sep):
+            return None
+    # Pick the smallest prefix that contains both the executable and
+    # its support files.  ``sys.base_prefix`` is the right answer for
+    # venvs (where ``sys.prefix`` points at the venv, but the actual
+    # interpreter binary and stdlib live under ``base_prefix``).  We
+    # can't query the subprocess's interpreter from here without
+    # spawning it, so we use the running interpreter's base_prefix
+    # when the requested exe matches ``sys.executable``; otherwise we
+    # fall back to ascending two directories from the binary path
+    # (``<prefix>/bin/python3`` -> ``<prefix>``), which covers every
+    # standard install layout we've seen.
+    if os.path.realpath(sys.executable) == real_exe:
+        prefix = os.path.realpath(sys.base_prefix)
+    else:
+        prefix = os.path.dirname(os.path.dirname(real_exe))
+    # Mount at the same absolute path so the argv we pass to isolate
+    # resolves inside the chroot.  isolate's ``--dir`` strips the
+    # leading ``/`` for us (target is relative to the sandbox root).
+    target = prefix.lstrip("/")
+    return (target, prefix, "")
+
+
 def build_run_plan(
     request: Request,
     *,
@@ -203,11 +257,19 @@ def build_run_plan(
     already supplies sensible defaults (1s, 1400 MB) so the runner
     doesn't need to layer its own.  Tests that need a different
     limit override it on the request.
+
+    If ``python_executable`` (or ``sys.executable`` when omitted)
+    lives outside isolate's default bind-mount roots, an extra
+    ``--dir`` rule is added so the chroot can see and ``execve`` it.
     """
     time_limit = request.time_limit_seconds
     wall_limit = time_limit * DEFAULT_WALL_TIME_MULTIPLIER
     mem_mb = request.memory_limit_mb
     python_exe = python_executable or sys.executable
+    all_extra_dirs = list(extra_dirs)
+    python_mount = _python_prefix_mount(python_exe)
+    if python_mount is not None and python_mount not in all_extra_dirs:
+        all_extra_dirs.append(python_mount)
     return RunPlan(
         box_id=box_id,
         submission_dir=request.submission_dir,
@@ -219,7 +281,7 @@ def build_run_plan(
         memory_limit_mb=mem_mb,
         processes=DEFAULT_PROCESSES,
         fsize_kb=DEFAULT_FSIZE_KB,
-        extra_dirs=tuple(extra_dirs),
+        extra_dirs=tuple(all_extra_dirs),
         isolate_binary=isolate_binary,
     )
 

--- a/src/generic_grader/sandbox/runner.py
+++ b/src/generic_grader/sandbox/runner.py
@@ -110,11 +110,19 @@ class RunPlan:
             "--fsize",
             str(self.fsize_kb),
             # /box/submission is the worker's CWD and is writable.
+            # ``isolate --dir`` interprets the target path as relative
+            # to the box root (which is mounted at ``/box`` inside the
+            # sandbox), so we pass ``submission=<host>:rw`` and *not*
+            # ``/box/submission=<host>:rw``.  Using the absolute form
+            # causes isolate to error with ``Cannot mount ... on
+            # box/submission: Permission denied`` because it strips the
+            # leading slash and then tries to mount at
+            # ``<box_root>/box/submission`` -- doubled-up.
             "--dir",
-            f"/box/submission={self.submission_dir}:rw",
+            f"submission={self.submission_dir}:rw",
             # /box/grader is the generic_grader install, read only.
             "--dir",
-            f"/box/grader={self.grader_src}",
+            f"grader={self.grader_src}",
             # Set PYTHONPATH and a sane cwd.
             "--env",
             "PYTHONPATH=/box/grader",

--- a/src/generic_grader/sandbox/runner.py
+++ b/src/generic_grader/sandbox/runner.py
@@ -31,13 +31,15 @@ real install when one is available.
 from __future__ import annotations
 
 import io
+import json
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from dataclasses import dataclass, field, replace
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
 from generic_grader.sandbox.protocol import (
     Request,
@@ -69,6 +71,31 @@ DEFAULT_FSIZE_KB = 65536  # 64 MB of file writes per test
 # inside the isolate cap on slow hosts (e.g. Gradescope CI
 # containers).
 STARTUP_OVERHEAD_SECONDS = 10.0
+
+# When ``GENERIC_GRADER_PROFILE`` is set to a writable file path, the
+# runner appends one JSON line per sandbox call describing where the
+# time went.  Unset means zero overhead -- the worker still records
+# its checkpoint list (5 ``perf_counter`` calls, ~250 ns) but the
+# host never opens a file or formats anything.
+#
+# Each line has the shape::
+#
+#   {"request": {"module": ..., "obj_name": ...},
+#    "host":    {"init_seconds": ..., "run_seconds": ...,
+#                "cleanup_seconds": ..., "total_seconds": ...},
+#    "isolate": {"time": ..., "time-wall": ..., "max-rss": ...},
+#    "worker":  {"checkpoints": [[name, seconds_since_enter], ...],
+#                "elapsed_seconds": ...}}
+#
+# This is a debugging knob, not part of the public API; the env-var
+# name carries the ``GENERIC_GRADER_`` prefix to keep it out of the
+# way of student / grader env namespaces.
+PROFILE_ENV_VAR = "GENERIC_GRADER_PROFILE"
+
+# Meta-file keys we surface in the profile line.  Anything else in
+# the meta file is dropped from the profile but still classified by
+# :func:`classify_meta`.
+_PROFILE_META_KEYS = ("time", "time-wall", "max-rss", "status", "exitcode")
 
 # isolate bind-mounts the following host paths by default (see
 # ``init_dir_rules`` in upstream ``rules.c``).  When the Python
@@ -407,6 +434,105 @@ def classify_meta(meta: dict[str, str]) -> dict[str, str] | None:
 
 
 # ---------------------------------------------------------------------------
+# Profile log writer
+# ---------------------------------------------------------------------------
+
+
+def _profile_destination() -> str | None:
+    """Return the path to write profile records to, or ``None`` if disabled.
+
+    A blank value (``""``) is treated as disabled so callers can clear
+    the env var without having to ``unset`` it.
+    """
+    dest = os.environ.get(PROFILE_ENV_VAR)
+    if not dest:
+        return None
+    return dest
+
+
+def _extract_worker_profile(response: Response) -> dict[str, Any] | None:
+    """Pull the worker's profile event out of `response`, if present.
+
+    The worker emits one ``Event(type="profile", checkpoints=[...])``
+    per request.  We surface it as a small dict; older workers (or
+    failed runs that never produced a frame) won't have one.
+    """
+    for event in response.events or ():
+        if event.type == "profile":
+            return {
+                "checkpoints": list(event.extra.get("checkpoints", ())),
+                "elapsed_seconds": response.elapsed_seconds,
+            }
+    return None
+
+
+def _meta_profile_subset(meta: dict[str, str]) -> dict[str, Any]:
+    """Pick the meta-file keys we want in profile records.
+
+    isolate's meta file uses string values throughout; we coerce the
+    numeric ones so downstream tooling doesn't have to.
+    """
+    out: dict[str, Any] = {}
+    for key in _PROFILE_META_KEYS:
+        if key not in meta:
+            continue
+        raw = meta[key]
+        if key in ("time", "time-wall"):
+            try:
+                out[key] = float(raw)
+                continue
+            except ValueError:  # pragma: no cover - meta is well-formed
+                pass
+        if key in ("max-rss", "exitcode"):
+            try:
+                out[key] = int(raw)
+                continue
+            except ValueError:  # pragma: no cover - meta is well-formed
+                pass
+        out[key] = raw
+    return out
+
+
+def _write_profile_record(
+    dest: str,
+    *,
+    request: Request,
+    host_timings: dict[str, float],
+    meta_text: str | None,
+    response: Response | None,
+) -> None:
+    """Append one JSON line summarizing the run to `dest`.
+
+    A failure to open or write the file is intentionally silent --
+    profiling is a debugging knob, and we don't want it to escalate
+    a half-broken disk into a grader failure.
+    """
+    record: dict[str, Any] = {
+        "request": {
+            "module": request.module,
+            "obj_name": request.obj_name,
+            "submission_dir": request.submission_dir,
+        },
+        "host": host_timings,
+    }
+    if meta_text is not None:
+        record["isolate"] = _meta_profile_subset(parse_meta(meta_text))
+    if response is not None:
+        worker = _extract_worker_profile(response)
+        if worker is not None:
+            record["worker"] = worker
+    line = json.dumps(record, separators=(",", ":")) + "\n"
+    try:
+        # Append-mode is intentional: many sandbox calls per grader
+        # run produce one line each, building up a profile log.
+        with open(dest, "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError:
+        # Profiling must never break grading.
+        pass
+
+
+# ---------------------------------------------------------------------------
 # Subprocess hook
 # ---------------------------------------------------------------------------
 
@@ -458,6 +584,15 @@ class IsolateRunner:
                 "`sudo isolate --init` once before grading."
             )
 
+        profile_dest = _profile_destination()
+        # ``perf_counter`` is monotonic and cheap (~250 ns); a handful
+        # of calls per request is well below the noise floor of any
+        # downstream timing we'd care to measure.
+        t_enter = time.perf_counter()
+        host_timings: dict[str, float] = {}
+        response: Response | None = None
+        meta_text: str | None = None
+
         meta_fd, meta_path = tempfile.mkstemp(prefix="isolate-meta-", suffix=".txt")
         os.close(meta_fd)
         try:
@@ -471,12 +606,15 @@ class IsolateRunner:
                 extra_dirs=self.extra_dirs,
             )
 
+            t_init_start = time.perf_counter()
             init = self.subprocess_runner(
                 plan.init_argv(),
                 capture_output=True,
                 text=True,
                 check=False,
             )
+            t_init_end = time.perf_counter()
+            host_timings["init_seconds"] = t_init_end - t_init_start
             if init.returncode != 0:
                 raise SandboxException(
                     f"`isolate --init` failed for box_id={self.box_id}: "
@@ -492,12 +630,15 @@ class IsolateRunner:
                 # spec, which is exactly what's needed there.
                 worker_request = replace(request, submission_dir=SANDBOX_SUBMISSION_DIR)
                 stdin_bytes = _encode_request(worker_request)
+                t_run_start = time.perf_counter()
                 completed = self.subprocess_runner(
                     plan.run_argv(),
                     input=stdin_bytes,
                     capture_output=True,
                     check=False,
                 )
+                t_run_end = time.perf_counter()
+                host_timings["run_seconds"] = t_run_end - t_run_start
                 stdout_bytes = completed.stdout or b""
                 if len(stdout_bytes) > self.max_response_bytes:
                     raise SandboxException(
@@ -506,24 +647,41 @@ class IsolateRunner:
                         "indicates a malformed worker that wrote outside the "
                         "framed protocol; check the worker's stderr for clues."
                     )
+                # Read the meta file once and reuse the text both for
+                # response decoding and (when enabled) profile logging.
+                # ``_decode_response_or_raise`` is happy to be handed
+                # the already-read text instead of a path.
+                meta_text = _read_meta(meta_path)
                 response = _decode_response_or_raise(
                     stdout_bytes,
                     completed.stderr,
                     completed.returncode,
-                    meta_path,
+                    meta_text,
                 )
             finally:
+                t_cleanup_start = time.perf_counter()
                 self.subprocess_runner(
                     plan.cleanup_argv(),
                     capture_output=True,
                     text=True,
                     check=False,
                 )
+                t_cleanup_end = time.perf_counter()
+                host_timings["cleanup_seconds"] = t_cleanup_end - t_cleanup_start
         finally:
             try:
                 os.unlink(meta_path)
             except OSError:  # pragma: no cover - best effort
                 pass
+            if profile_dest is not None:
+                host_timings["total_seconds"] = time.perf_counter() - t_enter
+                _write_profile_record(
+                    profile_dest,
+                    request=request,
+                    host_timings=host_timings,
+                    meta_text=meta_text,
+                    response=response,
+                )
 
         return response
 
@@ -540,11 +698,25 @@ def _encode_request(request: Request) -> bytes:
     return buf.getvalue()
 
 
+def _read_meta(meta_path: str) -> str:
+    """Read isolate's meta file, returning ``""`` if it can't be read.
+
+    Pulled out into its own helper so the runner can read the meta
+    text once and hand it to both the response decoder and the
+    optional profile writer without re-opening the file.
+    """
+    try:
+        with open(meta_path, encoding="utf-8") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
 def _decode_response_or_raise(
     stdout_bytes: bytes,
     stderr_bytes: bytes,
     exit_code: int,
-    meta_path: str,
+    meta_text: str,
 ) -> Response:
     """Decode the worker's response or synthesize one from the meta file.
 
@@ -565,12 +737,6 @@ def _decode_response_or_raise(
        student can see Python's complaint about a missing module
        etc.
     """
-    meta_text = ""
-    try:
-        with open(meta_path, encoding="utf-8") as f:
-            meta_text = f.read()
-    except OSError:
-        meta_text = ""
     meta = parse_meta(meta_text)
     classified = classify_meta(meta)
 

--- a/src/generic_grader/sandbox/runner.py
+++ b/src/generic_grader/sandbox/runner.py
@@ -197,8 +197,16 @@ class RunPlan:
         return argv
 
 
-def _python_prefix_mount(python_exe: str) -> tuple[str, str, str] | None:
-    """Return an ``extra_dirs`` entry exposing ``python_exe`` in the sandbox.
+def _path_in_default_mounts(path: str) -> bool:
+    """Is ``path`` inside one of isolate's built-in bind-mount roots?"""
+    for root in _ISOLATE_DEFAULT_MOUNT_ROOTS:
+        if path == root or path.startswith(root + os.sep):
+            return True
+    return False
+
+
+def _python_prefix_mounts(python_exe: str) -> list[tuple[str, str, str]]:
+    """Return ``extra_dirs`` entries that make ``python_exe`` reachable.
 
     isolate's default ``--dir`` rules cover ``/bin``, ``/lib``,
     ``/lib64``, and ``/usr``.  A Python interpreter installed by
@@ -207,38 +215,55 @@ def _python_prefix_mount(python_exe: str) -> tuple[str, str, str] | None:
     with ``No such file or directory`` (exit 127).
 
     To make such an interpreter reachable we bind-mount its prefix
-    (e.g. ``~/.local/share/uv/python/cpython-3.12.X-...``) into the
-    sandbox at the *same* host path.  Binding at the original path
-    means the absolute ``python_executable`` argv string we already
-    pass to ``--run`` resolves correctly inside the chroot, without
-    any path rewriting.
+    -- e.g. ``~/.local/share/uv/python/cpython-3.12.X-...`` for a
+    uv-managed python, or ``/env`` for the Gradescope grader venv --
+    into the sandbox at the *same* host path.  Binding at the
+    original path means the absolute ``python_executable`` argv
+    string we already pass to ``--run`` resolves correctly inside
+    the chroot, without any path rewriting.
 
-    Returns ``None`` if the executable is already inside one of
-    isolate's default mount roots and no extra mount is needed.
+    We deliberately do *not* follow symlinks when deciding whether
+    a mount is needed: if the literal argv path lives outside
+    ``/usr`` (e.g. a venv binary at ``/env/bin/python3.13`` that
+    symlinks to ``/usr/bin/python3.13``), the chroot must still see
+    the literal path so ``execve`` can resolve it.
+
+    When the venv's interpreter symlinks to a base prefix that is
+    *also* outside the default mounts (uv, pyenv, conda), we add a
+    second mount for that prefix so the linker can find the stdlib
+    and shared libraries.
+
+    Returns an empty list if no extra mounts are needed.
     """
-    real_exe = os.path.realpath(python_exe)
-    for root in _ISOLATE_DEFAULT_MOUNT_ROOTS:
-        if real_exe == root or real_exe.startswith(root + os.sep):
-            return None
-    # Pick the smallest prefix that contains both the executable and
-    # its support files.  ``sys.base_prefix`` is the right answer for
-    # venvs (where ``sys.prefix`` points at the venv, but the actual
-    # interpreter binary and stdlib live under ``base_prefix``).  We
-    # can't query the subprocess's interpreter from here without
-    # spawning it, so we use the running interpreter's base_prefix
-    # when the requested exe matches ``sys.executable``; otherwise we
-    # fall back to ascending two directories from the binary path
-    # (``<prefix>/bin/python3`` -> ``<prefix>``), which covers every
-    # standard install layout we've seen.
-    if os.path.realpath(sys.executable) == real_exe:
-        prefix = os.path.realpath(sys.base_prefix)
+    if _path_in_default_mounts(python_exe):
+        return []
+    # Pick the smallest prefix that contains the executable.  When
+    # the caller asks us to run the current interpreter we know it
+    # is ``sys.prefix`` (the venv root, which contains the
+    # ``bin/python`` entry the chroot must see).  Otherwise we fall
+    # back to ascending two directories from the binary path
+    # (``<prefix>/bin/python3`` -> ``<prefix>``).
+    if sys.executable == python_exe:
+        prefix = sys.prefix
     else:
-        prefix = os.path.dirname(os.path.dirname(real_exe))
+        prefix = os.path.dirname(os.path.dirname(python_exe))
     # Mount at the same absolute path so the argv we pass to isolate
     # resolves inside the chroot.  isolate's ``--dir`` strips the
     # leading ``/`` for us (target is relative to the sandbox root).
-    target = prefix.lstrip("/")
-    return (target, prefix, "")
+    mounts: list[tuple[str, str, str]] = [(prefix.lstrip("/"), prefix, "")]
+    # If the venv's base interpreter also lives outside the default
+    # mounts (uv, pyenv, conda), expose it too -- the linker needs
+    # to find ``libpython*.so`` and the stdlib under ``base_prefix``.
+    if sys.executable == python_exe and sys.base_prefix != sys.prefix:
+        base = sys.base_prefix
+        if (
+            not _path_in_default_mounts(base)
+            and base != prefix
+            and not base.startswith(prefix + os.sep)
+            and not prefix.startswith(base + os.sep)
+        ):
+            mounts.append((base.lstrip("/"), base, ""))
+    return mounts
 
 
 def build_run_plan(
@@ -267,9 +292,9 @@ def build_run_plan(
     mem_mb = request.memory_limit_mb
     python_exe = python_executable or sys.executable
     all_extra_dirs = list(extra_dirs)
-    python_mount = _python_prefix_mount(python_exe)
-    if python_mount is not None and python_mount not in all_extra_dirs:
-        all_extra_dirs.append(python_mount)
+    for python_mount in _python_prefix_mounts(python_exe):
+        if python_mount not in all_extra_dirs:
+            all_extra_dirs.append(python_mount)
     return RunPlan(
         box_id=box_id,
         submission_dir=request.submission_dir,

--- a/src/generic_grader/sandbox/runner.py
+++ b/src/generic_grader/sandbox/runner.py
@@ -60,16 +60,15 @@ DEFAULT_FSIZE_KB = 65536  # 64 MB of file writes per test
 # startup, ``site``/grader imports, ``matplotlib`` if it's pulled in,
 # the worker protocol round-trip, and only then the student call.
 #
-# We add a fixed allowance on top of the student budget before passing
-# it to isolate so a typical ``time_limit=1`` test doesn't get killed
-# during interpreter startup on slower hosts (e.g. Gradescope CI
-# containers, where a cold ``python -m`` can chew through several
-# hundred milliseconds before the worker even reads the request).
-#
-# Step 2 of the timeout fix will additionally enforce the student
-# budget inside the worker with its own ``SIGALRM`` so the isolate
-# limit becomes purely a safety net.
-STARTUP_OVERHEAD_SECONDS = 2.0
+# The Python runtime worker enforces the student budget itself via
+# ``_student_call_time_limit`` (see ``python_runtime.py``); the value
+# we send to isolate is therefore a *safety net*, not the primary
+# enforcement.  We add a generous allowance on top of the student
+# budget so that interpreter startup, ``matplotlib`` / grader
+# imports, and the figure-serialization tail are all comfortably
+# inside the isolate cap on slow hosts (e.g. Gradescope CI
+# containers).
+STARTUP_OVERHEAD_SECONDS = 10.0
 
 # isolate bind-mounts the following host paths by default (see
 # ``init_dir_rules`` in upstream ``rules.c``).  When the Python

--- a/src/generic_grader/sandbox/runner.py
+++ b/src/generic_grader/sandbox/runner.py
@@ -30,6 +30,7 @@ real install when one is available.
 
 from __future__ import annotations
 
+import io
 import os
 import shutil
 import subprocess
@@ -262,6 +263,16 @@ def _default_subprocess_runner(*args, **kwargs) -> subprocess.CompletedProcess:
     return subprocess.run(*args, **kwargs)
 
 
+# Hard cap on the worker's stdout the runner is willing to buffer.
+# ``subprocess.run(capture_output=True)`` reads the child's pipe into
+# memory; without a cap a runaway worker that emits unbounded data
+# (e.g. a flapping serializer in a tight loop) could OOM the host.
+# 64 MiB is far larger than any realistic protocol frame (events are
+# already capped indirectly by isolate's --fsize/wall-time limits)
+# while still being a hard ceiling.
+DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024 * 1024
+
+
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
@@ -277,6 +288,7 @@ class IsolateRunner:
     python_executable: str | None = None
     subprocess_runner: SubprocessRunner = _default_subprocess_runner
     extra_dirs: Sequence[tuple[str, str, str]] = ()
+    max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES
 
     # ------------------------------------------------------------------
     # Public API
@@ -324,8 +336,16 @@ class IsolateRunner:
                     capture_output=True,
                     check=False,
                 )
+                stdout_bytes = completed.stdout or b""
+                if len(stdout_bytes) > self.max_response_bytes:
+                    raise SandboxException(
+                        f"Worker stdout exceeded the {self.max_response_bytes}-byte "
+                        f"cap ({len(stdout_bytes)} bytes received). This typically "
+                        "indicates a malformed worker that wrote outside the "
+                        "framed protocol; check the worker's stderr for clues."
+                    )
                 response = _decode_response_or_raise(
-                    completed.stdout,
+                    stdout_bytes,
                     completed.stderr,
                     completed.returncode,
                     meta_path,
@@ -353,8 +373,6 @@ class IsolateRunner:
 
 def _encode_request(request: Request) -> bytes:
     """Serialize a request to the framed wire format as bytes."""
-    import io
-
     buf = io.BytesIO()
     write_request(buf, request)
     return buf.getvalue()
@@ -385,8 +403,6 @@ def _decode_response_or_raise(
        student can see Python's complaint about a missing module
        etc.
     """
-    import io
-
     meta_text = ""
     try:
         with open(meta_path, encoding="utf-8") as f:

--- a/src/generic_grader/sandbox/runner.py
+++ b/src/generic_grader/sandbox/runner.py
@@ -36,7 +36,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Callable, Sequence
 
 from generic_grader.sandbox.protocol import (
@@ -51,6 +51,13 @@ DEFAULT_BOX_ID = 0
 DEFAULT_WALL_TIME_MULTIPLIER = 2.0
 DEFAULT_PROCESSES = 64
 DEFAULT_FSIZE_KB = 65536  # 64 MB of file writes per test
+
+# The host-side submission directory is bind-mounted at this path
+# inside the sandbox (see ``RunPlan.run_argv``).  The worker's CWD is
+# also set to this path.  We rewrite ``Request.submission_dir`` to
+# this value before serializing the frame, since the worker has no
+# way to see the host path.
+SANDBOX_SUBMISSION_DIR = "/box/submission"
 
 
 # ---------------------------------------------------------------------------
@@ -329,7 +336,14 @@ class IsolateRunner:
                 )
 
             try:
-                stdin_bytes = _encode_request(request)
+                # The worker only sees ``/box/submission`` (the bind
+                # mount); rewrite ``submission_dir`` before encoding
+                # so ``_patched_cwd_and_path`` chdirs to a path that
+                # actually exists inside the sandbox.  The build_run_plan
+                # call above used the host path to construct the mount
+                # spec, which is exactly what's needed there.
+                worker_request = replace(request, submission_dir=SANDBOX_SUBMISSION_DIR)
+                stdin_bytes = _encode_request(worker_request)
                 completed = self.subprocess_runner(
                     plan.run_argv(),
                     input=stdin_bytes,

--- a/src/generic_grader/sandbox/runner.py
+++ b/src/generic_grader/sandbox/runner.py
@@ -57,7 +57,18 @@ DEFAULT_FSIZE_KB = 65536  # 64 MB of file writes per test
 # also set to this path.  We rewrite ``Request.submission_dir`` to
 # this value before serializing the frame, since the worker has no
 # way to see the host path.
-SANDBOX_SUBMISSION_DIR = "/box/submission"
+#
+# Note that isolate's chroot root is the sandbox root, *not* ``/box``.
+# By default isolate mounts the host ``<box_dir>/box`` directory at
+# the sandbox path ``/box`` and chdirs there before running the
+# program, but the default ``--dir`` mount points (``bin``, ``lib``,
+# ``submission``, ...) all live at the sandbox root.  isolate refuses
+# to create subdirectories in already-bound directories, so we cannot
+# mount inside ``/box`` without pre-creating the mountpoint.  Mounting
+# at the sandbox root is simpler and is what isolate does for every
+# other tool that uses it (gitlab-ci, MOE Judge, OI judge, ...).
+SANDBOX_SUBMISSION_DIR = "/submission"
+SANDBOX_GRADER_DIR = "/grader"
 
 
 # ---------------------------------------------------------------------------
@@ -105,38 +116,48 @@ class RunPlan:
             f"{self.wall_time_limit_seconds:.3f}",
             "--mem",
             str(self.memory_limit_mb * 1024),  # isolate expects KB
-            "--processes",
-            str(self.processes),
+            # ``--processes`` takes an *optional* argument per isolate's
+            # getopt spec (``-p, --processes[=<max>]``), so the value
+            # must be glued on with ``=``.  Passing them as separate
+            # tokens makes isolate ignore the max and treat the count
+            # as part of the command line, producing
+            # ``execve("<N>"): No such file or directory``.
+            f"--processes={self.processes}",
             "--fsize",
             str(self.fsize_kb),
-            # /box/submission is the worker's CWD and is writable.
-            # ``isolate --dir`` interprets the target path as relative
-            # to the box root (which is mounted at ``/box`` inside the
-            # sandbox), so we pass ``submission=<host>:rw`` and *not*
-            # ``/box/submission=<host>:rw``.  Using the absolute form
-            # causes isolate to error with ``Cannot mount ... on
-            # box/submission: Permission denied`` because it strips the
-            # leading slash and then tries to mount at
-            # ``<box_root>/box/submission`` -- doubled-up.
+            # ``isolate --dir`` target paths are relative to the
+            # sandbox root (isolate strips a leading ``/`` from the
+            # target).  We mount the host submission and grader at
+            # ``/submission`` and ``/grader`` in the sandbox.  We do
+            # *not* mount them under ``/box`` because isolate refuses
+            # to create subdirectories in bound directories, and
+            # ``/box`` is already a default bind-mount.
             "--dir",
             f"submission={self.submission_dir}:rw",
-            # /box/grader is the generic_grader install, read only.
+            # /grader is the generic_grader install, read only.
             "--dir",
             f"grader={self.grader_src}",
             # Set PYTHONPATH and a sane cwd.
             "--env",
-            "PYTHONPATH=/box/grader",
+            "PYTHONPATH=/grader",
             "--env",
             "MPLBACKEND=Agg",
             "--env",
-            "HOME=/box/submission",
+            "HOME=/submission",
+            # ``--chdir`` takes a path that, when ``chdir(2)``-ed from
+            # the sandbox cwd (which is ``/box`` by default), lands at
+            # the desired location.  Using ``/submission`` (absolute
+            # under the chroot) is the most explicit form and works
+            # regardless of any future change to the default cwd.
             "--chdir",
-            "/box/submission",
+            "/submission",
             # Default isolate already disables network; pass --share-net
             # is what enables it, so we deliberately omit that flag.
         ]
         for name, source, opts in self.extra_dirs:
-            spec = f"/box/{name}={source}"
+            # Mount targets must be relative to the box root; see the
+            # comment on the ``submission`` mount above.
+            spec = f"{name}={source}"
             if opts:
                 spec = f"{spec}:{opts}"
             argv.extend(["--dir", spec])
@@ -145,8 +166,20 @@ class RunPlan:
                 "--run",
                 "--",
                 self.python_executable,
-                "-I",
+                # We *cannot* use ``-I`` (isolated mode) here because
+                # it implies ``-E``, which makes Python ignore
+                # ``PYTHONPATH`` -- and we rely on ``PYTHONPATH`` to
+                # point at the bind-mounted grader install.  Instead
+                # we pass the individual flags we want:
+                #   ``-S`` -- do not run ``site.py`` on startup.
+                #   ``-s`` -- do not add the per-user site directory.
+                #   ``-P`` -- do not prepend the script's directory
+                #             (or ``''`` for ``-m``) to ``sys.path``.
+                #             Requires Python 3.11+, which is our
+                #             minimum per ``pyproject.toml``.
                 "-S",
+                "-s",
+                "-P",
                 "-m",
                 "generic_grader.sandbox.worker_main",
             ]
@@ -344,7 +377,7 @@ class IsolateRunner:
                 )
 
             try:
-                # The worker only sees ``/box/submission`` (the bind
+                # The worker only sees ``/submission`` (the bind
                 # mount); rewrite ``submission_dir`` before encoding
                 # so ``_patched_cwd_and_path`` chdirs to a path that
                 # actually exists inside the sandbox.  The build_run_plan

--- a/src/generic_grader/sandbox/runner.py
+++ b/src/generic_grader/sandbox/runner.py
@@ -52,6 +52,25 @@ DEFAULT_WALL_TIME_MULTIPLIER = 2.0
 DEFAULT_PROCESSES = 64
 DEFAULT_FSIZE_KB = 65536  # 64 MB of file writes per test
 
+# ``Request.time_limit_seconds`` carries the *student-code* budget
+# (matching the legacy non-sandbox ``Options.time_limit`` semantics --
+# see ``generic_grader.utils.resource_limits.time_limit``, which wraps
+# only the student call in a ``SIGALRM`` alarm).  Isolate's ``--time``,
+# in contrast, counts CPU for the *entire* subprocess: interpreter
+# startup, ``site``/grader imports, ``matplotlib`` if it's pulled in,
+# the worker protocol round-trip, and only then the student call.
+#
+# We add a fixed allowance on top of the student budget before passing
+# it to isolate so a typical ``time_limit=1`` test doesn't get killed
+# during interpreter startup on slower hosts (e.g. Gradescope CI
+# containers, where a cold ``python -m`` can chew through several
+# hundred milliseconds before the worker even reads the request).
+#
+# Step 2 of the timeout fix will additionally enforce the student
+# budget inside the worker with its own ``SIGALRM`` so the isolate
+# limit becomes purely a safety net.
+STARTUP_OVERHEAD_SECONDS = 2.0
+
 # isolate bind-mounts the following host paths by default (see
 # ``init_dir_rules`` in upstream ``rules.c``).  When the Python
 # executable we want to run lives outside *all* of these roots --
@@ -278,16 +297,18 @@ def build_run_plan(
 ) -> RunPlan:
     """Construct a :class:`RunPlan` from a :class:`Request`.
 
-    Resource limits come straight from the request -- `Request`
-    already supplies sensible defaults (1s, 1400 MB) so the runner
-    doesn't need to layer its own.  Tests that need a different
-    limit override it on the request.
+    Resource limits derive from the request -- `Request` already
+    supplies sensible defaults (1s student-code budget, 1400 MB).
+    The runner adds :data:`STARTUP_OVERHEAD_SECONDS` to the CPU
+    budget before passing it to isolate so interpreter startup and
+    grader-side imports don't eat into the student's time budget.
 
     If ``python_executable`` (or ``sys.executable`` when omitted)
     lives outside isolate's default bind-mount roots, an extra
     ``--dir`` rule is added so the chroot can see and ``execve`` it.
     """
-    time_limit = request.time_limit_seconds
+    student_budget = request.time_limit_seconds
+    time_limit = student_budget + STARTUP_OVERHEAD_SECONDS
     wall_limit = time_limit * DEFAULT_WALL_TIME_MULTIPLIER
     mem_mb = request.memory_limit_mb
     python_exe = python_executable or sys.executable

--- a/src/generic_grader/sandbox/worker_main.py
+++ b/src/generic_grader/sandbox/worker_main.py
@@ -1,0 +1,74 @@
+"""Entry point that runs inside the isolate sandbox.
+
+`isolate` invokes ``python -m generic_grader.sandbox.worker_main``.
+This module reads exactly one framed `Request` from stdin, runs it
+through `python_runtime.run_request`, writes the framed `Response`
+to stdout, then exits.
+
+It deliberately performs no work outside that critical path so that:
+
+* The sandbox subprocess starts as fast as possible (no eager
+  matplotlib import; `python_runtime` itself imports lazily).
+* If the worker dies for any reason, the host can still distinguish
+  a malformed/missing frame from a worker crash by checking the
+  return code and the empty / partial stdout.
+
+This module also serves as the in-process entry point used by the
+unit tests for the runner: tests spawn ``python -m
+generic_grader.sandbox.worker_main`` directly (no `isolate` wrapper)
+as a stand-in for the real sandboxed subprocess.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from generic_grader.sandbox.protocol import (
+    SandboxException,
+    read_request,
+    write_response,
+)
+from generic_grader.sandbox.python_runtime import run_request
+
+
+def main(stdin=None, stdout=None) -> int:
+    """Read one request, run it, write one response. Return process exit code.
+
+    stdin/stdout default to the binary buffers of the real process
+    streams so the framed protocol stays byte-exact. Tests can pass
+    in BytesIO buffers to exercise this entry point in-process.
+    """
+    stdin = stdin if stdin is not None else sys.stdin.buffer
+    stdout = stdout if stdout is not None else sys.stdout.buffer
+
+    try:
+        request = read_request(stdin)
+    except SandboxException as e:
+        # If we can't even parse the request, surface the failure to
+        # the host as a structured exception on an otherwise-empty
+        # response. The host treats this as a runner-level failure.
+        from generic_grader.sandbox.protocol import Response
+
+        write_response(
+            stdout,
+            Response(
+                events=[],
+                exception=[
+                    {
+                        "type": "SandboxProtocolError",
+                        "message": str(e),
+                        "traceback": "",
+                    }
+                ],
+                elapsed_seconds=0.0,
+            ),
+        )
+        return 2
+
+    response = run_request(request)
+    write_response(stdout, response)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - smoke executed from runner tests
+    raise SystemExit(main())

--- a/src/generic_grader/sandbox/worker_main.py
+++ b/src/generic_grader/sandbox/worker_main.py
@@ -41,27 +41,37 @@ def main(stdin=None, stdout=None) -> int:
     stdin = stdin if stdin is not None else sys.stdin.buffer
     stdout = stdout if stdout is not None else sys.stdout.buffer
 
+    from generic_grader.sandbox.protocol import Response
+
+    def _protocol_error(message: str) -> Response:
+        return Response(
+            events=[],
+            exception=[
+                {
+                    "type": "SandboxProtocolError",
+                    "message": message,
+                    "traceback": "",
+                }
+            ],
+            elapsed_seconds=0.0,
+        )
+
     try:
         request = read_request(stdin)
     except SandboxException as e:
-        # If we can't even parse the request, surface the failure to
+        # If we can't even parse the frame, surface the failure to
         # the host as a structured exception on an otherwise-empty
         # response. The host treats this as a runner-level failure.
-        from generic_grader.sandbox.protocol import Response
+        write_response(stdout, _protocol_error(str(e)))
+        return 2
 
+    if request is None:
+        # Clean EOF before any frame was sent.  Surface this as a
+        # protocol error rather than letting `run_request(None)` crash
+        # with an opaque ``AttributeError``.
         write_response(
             stdout,
-            Response(
-                events=[],
-                exception=[
-                    {
-                        "type": "SandboxProtocolError",
-                        "message": str(e),
-                        "traceback": "",
-                    }
-                ],
-                elapsed_seconds=0.0,
-            ),
+            _protocol_error("No request frame received from host."),
         )
         return 2
 
@@ -70,5 +80,5 @@ def main(stdin=None, stdout=None) -> int:
     return 0
 
 
-if __name__ == "__main__":  # pragma: no cover - smoke executed from runner tests
+if __name__ == "__main__":  # pragma: no cover - exercised only as a real subprocess
     raise SystemExit(main())

--- a/src/generic_grader/sandbox/worker_main.py
+++ b/src/generic_grader/sandbox/worker_main.py
@@ -24,11 +24,46 @@ from __future__ import annotations
 import sys
 
 from generic_grader.sandbox.protocol import (
+    Request,
+    Response,
     SandboxException,
     read_request,
     write_response,
 )
-from generic_grader.sandbox.python_runtime import run_request
+
+
+def _dispatch_request(request: Request) -> Response:
+    """Pick a runtime worker by ``request.runtime`` and run the request.
+
+    Imports are lazy so a Python-only worker doesn't pay the import
+    cost for the Octave stub (which itself is tiny, but the principle
+    keeps the dispatcher honest for heavier future runtimes).
+    Unknown runtimes are surfaced as a structured error response
+    rather than an opaque ``KeyError`` / ``ModuleNotFoundError``.
+    """
+    runtime = (request.runtime or "").lower()
+    if runtime == "python":
+        from generic_grader.sandbox.python_runtime import run_request
+
+        return run_request(request)
+    if runtime == "octave":
+        from generic_grader.sandbox.octave_runtime import run_request
+
+        return run_request(request)
+    return Response(
+        events=[],
+        exception=[
+            {
+                "type": "UnknownRuntimeError",
+                "message": (
+                    f"Unknown sandbox runtime {request.runtime!r}.  "
+                    "Supported runtimes are 'python' and 'octave'."
+                ),
+                "traceback": "",
+            }
+        ],
+        elapsed_seconds=0.0,
+    )
 
 
 def main(stdin=None, stdout=None) -> int:
@@ -40,8 +75,6 @@ def main(stdin=None, stdout=None) -> int:
     """
     stdin = stdin if stdin is not None else sys.stdin.buffer
     stdout = stdout if stdout is not None else sys.stdout.buffer
-
-    from generic_grader.sandbox.protocol import Response
 
     def _protocol_error(message: str) -> Response:
         return Response(
@@ -75,7 +108,7 @@ def main(stdin=None, stdout=None) -> int:
         )
         return 2
 
-    response = run_request(request)
+    response = _dispatch_request(request)
     write_response(stdout, response)
     return 0
 

--- a/src/generic_grader/utils/importer.py
+++ b/src/generic_grader/utils/importer.py
@@ -7,9 +7,21 @@ from pathlib import Path
 from attrs import evolve
 
 from generic_grader.utils.docs import get_wrapper
-from generic_grader.utils.exceptions import handle_error, safe_exception_type
+from generic_grader.utils.exceptions import (
+    EndOfInputError,
+    handle_error,
+    safe_exception_type,
+)
 from generic_grader.utils.options import Options
 from generic_grader.utils.patches import custom_stack
+
+# Sentinel returned by `Importer.import_obj` when `Options.use_sandbox`
+# is set.  In sandbox mode there is no live callable to return (the
+# real object lives inside the worker process, which exits between
+# import and call), but the existing `__User__.__init__` only needs a
+# truthy attribute.  `__User__.call_obj` checks for this sentinel and
+# delegates to the sandbox integration module.
+SANDBOX_OBJ_SENTINEL = object()
 
 
 class Importer:
@@ -52,6 +64,9 @@ class Importer:
         """Import and return the requested object from module. Special
         handling is applied to catch input() statements and missing
         objects."""
+        if o.use_sandbox:
+            return cls._sandbox_import_obj(test, module, o)
+
         obj_name = o.obj_name
 
         imp_obj = None
@@ -139,3 +154,132 @@ class Importer:
             test.fail("\n" + fail_msg)
 
         return imp_obj
+
+    # ------------------------------------------------------------------
+    # Sandbox path (Layer 3, gated on Options.use_sandbox)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _sandbox_import_obj(cls, test: unittest.TestCase, module: str, o: Options):
+        """Sandbox-backed equivalent of `import_obj`.
+
+        Runs an import-only probe through a fresh isolate worker.  The
+        classifier turns the worker's structured outcome back into the
+        same student-facing failure messages produced by the in-process
+        path (above), so existing assignments don't need to change
+        anything besides setting ``Options.use_sandbox=True``.
+        """
+        # Imported lazily so projects that never opt into the sandbox
+        # don't pay the import cost for the runner / isolate machinery.
+        from generic_grader.sandbox.integration import (
+            classify_import_outcome,
+            sandbox_import_obj,
+        )
+
+        obj_name = o.obj_name
+        result = sandbox_import_obj(module, o)
+        outcome = classify_import_outcome(result)
+        if outcome is None:
+            return SANDBOX_OBJ_SENTINEL
+
+        fail_msg = cls._format_sandbox_import_failure(outcome, result, module, obj_name)
+        test.failureException = outcome
+        test.fail("\n" + fail_msg)
+
+    @classmethod
+    def _format_sandbox_import_failure(
+        cls,
+        outcome: type[BaseException],
+        result,
+        module: str,
+        obj_name: str,
+    ) -> str:
+        """Render a sandbox import outcome as a student-facing failure message.
+
+        Mirrors the classification branches in `import_obj`: AttributeError
+        -> "unable to import obj", EndOfInputError -> "stuck at input",
+        ModuleNotFoundError -> module-resolution hint, anything else
+        -> generic handle_error-style traceback derived from the
+        worker's exception chain.
+        """
+        if outcome is AttributeError:
+            return (
+                cls.wrapper.fill(f"Unable to import `{obj_name}`.")
+                + "\n\nHint:\n"
+                + cls.wrapper.fill(
+                    f"Define `{obj_name}` in your `{module}` module, and make"
+                    " sure its definition is not inside of any other block."
+                )
+            )
+        if outcome is EndOfInputError:
+            return (
+                cls.wrapper.fill(
+                    f"Stuck at call to `input()` while importing `{obj_name}`."
+                )
+                + "\n\nHint:\n"
+                + cls.wrapper.fill(
+                    "Avoid calling `input()` in the global scope "
+                    "(i.e. outside of any function or other code block)."
+                )
+            )
+        if outcome is ModuleNotFoundError:
+            # We don't have a live traceback in the host process to
+            # walk; rely on the worker's structured message to surface
+            # the missing dependency name.  The legacy path's deeper
+            # chain-walk is preserved by `_extract_missing_module` so
+            # multi-step ``ImportError`` chains still produce the
+            # correct hint.
+            missing_name = cls._extract_missing_module(result, module)
+            if missing_name == module or module.startswith(missing_name + "."):
+                hint = (
+                    f"Make sure you have submitted a module named `{module}` and "
+                    f"it contains the definition of `{obj_name}`."
+                )
+            else:
+                hint = (
+                    f"Your `{module}` module imports `{missing_name}`, but "
+                    f"that module could not be found. `{missing_name}` may be "
+                    f"imported directly by `{module}`, or by another module that "
+                    f"`{module}` depends on. If it is your own module, make sure "
+                    "that it is included in your submission. If it is not your own "
+                    "module, that dependency may not be available in the autograder "
+                    "environment."
+                )
+            return (
+                cls.wrapper.fill(f"Unable to import `{module}`.")
+                + "\n\nHint:\n"
+                + cls.wrapper.fill(hint)
+            )
+
+        # Generic fallback: build a traceback-style message from the
+        # worker's structured exception chain.
+        chain = result.exception or []
+        head = chain[0] if chain else {"type": outcome.__name__, "message": ""}
+        tb_text = head.get("traceback") or ""
+        formatted = (
+            ("Traceback (most recent call last):\n" + tb_text) if tb_text else ""
+        ) + f"{head.get('type', outcome.__name__)}: {head.get('message', '')}\n"
+        from generic_grader.utils.exceptions import indent
+
+        return indent(f"Error while importing `{obj_name}`.\n\n" + formatted)
+
+    @staticmethod
+    def _extract_missing_module(result, module: str) -> str:
+        """Pull the deepest missing module name out of a worker exception chain.
+
+        The legacy path walks the live ``__cause__`` / ``__context__``
+        chain and prefers the deepest ``ModuleNotFoundError.name``.  We
+        approximate that by scanning the structured chain for messages
+        of the form ``No module named 'X'`` (CPython's canonical text)
+        and picking the deepest one.
+        """
+        import re
+
+        missing = module
+        pattern = re.compile(r"No module named '([^']+)'")
+        for link in result.exception or []:
+            if link.get("type") == "ModuleNotFoundError":
+                match = pattern.search(link.get("message") or "")
+                if match:
+                    missing = match.group(1)
+        return missing

--- a/src/generic_grader/utils/options.py
+++ b/src/generic_grader/utils/options.py
@@ -29,6 +29,15 @@ class Options:
     As of right now, those functions are `str` and `int`.
     """
 
+    # Sandbox (Layer 3) opt-in.  When True, import and call run in a fresh
+    # `isolate`-backed worker per call; the in-process Layer 1 path is
+    # bypassed.  Patches that need to cross the boundary must be supplied
+    # via `patch_specs` because live callables in `patches` cannot be
+    # JSON-serialized.  See `generic_grader.sandbox.patch_specs` for the
+    # helpers that build sandbox-safe specs.
+    use_sandbox: bool = False
+    patch_specs: tuple = ()
+
     # Input
     entries: tuple = ()
 
@@ -112,6 +121,13 @@ class Options:
             s = set(attr)
             if len(s) != len(attr):
                 raise ValueError(f"Duplicate entries in {name}.")
+        if self.use_sandbox and self.patches and not self.patch_specs:
+            raise ValueError(
+                "`use_sandbox=True` requires patches expressed as `patch_specs` "
+                "(JSON-serializable). The legacy `patches` field uses live "
+                "callables that cannot cross the sandbox boundary. See "
+                "`generic_grader.sandbox.patch_specs` for spec builders."
+            )
         if self.init is not None:
             sig = inspect.signature(self.init)
             positional_kinds = (

--- a/src/generic_grader/utils/options.py
+++ b/src/generic_grader/utils/options.py
@@ -19,6 +19,16 @@ class Options:
     weight: int | float = 0
     init: Callable | None = None
     ref_module: str = "tests.reference"
+    ref_dir: str = "./tests"
+    """
+    Directory (relative to the test harness CWD) that contains the reference
+    implementation and any supporting fixtures the reference code needs at
+    runtime.  This is currently only consulted by the Layer-3 sandbox
+    integration when ``use_sandbox=True``; the legacy in-process path imports
+    the reference module via the standard Python import machinery and ignores
+    this field.  Test authors are recommended to keep reference code and data
+    files under ``./tests/`` so they can be bind-mounted into the sandbox.
+    """
     sub_module: str = ""
     required_files: tuple = ()
     ignored_files: tuple = ()

--- a/src/generic_grader/utils/options.py
+++ b/src/generic_grader/utils/options.py
@@ -21,13 +21,20 @@ class Options:
     ref_module: str = "tests.reference"
     ref_dir: str = "./tests"
     """
-    Directory (relative to the test harness CWD) that contains the reference
+    Directory (relative to the test harness CWD) that holds the reference
     implementation and any supporting fixtures the reference code needs at
-    runtime.  This is currently only consulted by the Layer-3 sandbox
-    integration when ``use_sandbox=True``; the legacy in-process path imports
-    the reference module via the standard Python import machinery and ignores
-    this field.  Test authors are recommended to keep reference code and data
-    files under ``./tests/`` so they can be bind-mounted into the sandbox.
+    runtime.
+
+    **Not yet wired into the runtime.**  This field is declared so test
+    suites can adopt the option ahead of the bind-mount work, but the
+    Layer-3 sandbox integration in this PR does not yet bind-mount the
+    directory inside the sandbox; the value is currently read only by
+    user code and by the ``Options`` constructor.  Bind-mounting will
+    land in a follow-up PR (see ``ROADMAP.md``).  The legacy in-process
+    path imports the reference module via the standard Python import
+    machinery and likewise ignores this field.  Test authors are
+    recommended to keep reference code and data files under ``./tests/``
+    so they can be bind-mounted into the sandbox once that lands.
     """
     sub_module: str = ""
     required_files: tuple = ()

--- a/src/generic_grader/utils/plot.py
+++ b/src/generic_grader/utils/plot.py
@@ -5,11 +5,45 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
+def _draw_current_figure(test):
+    """Force a draw on the live current figure, no-op in sandbox mode.
+
+    The sandbox worker has already called ``canvas.draw()`` before
+    serializing, so the host-side facade already has the tick labels
+    populated.  When ``test._sandbox_figures`` is present we therefore
+    avoid touching ``plt`` at all.
+    """
+    if getattr(test, "_sandbox_figures", None):
+        return
+    plt.gcf().canvas.draw()
+
+
+def _sandbox_axes_for(test):
+    """Return the serialized-figure axes attached to ``test`` if any.
+
+    Sandbox-mode users (``User._sandbox_call_obj``) attach the most
+    recently produced figures to the test instance under
+    ``test._sandbox_figures``.  When that attribute is present we read
+    plot properties from the serialized dict via the host-side facade
+    instead of reaching into ``plt.gcf()`` -- the latter is empty
+    because the live figure lives in the sandbox process.
+    """
+    figures = getattr(test, "_sandbox_figures", None)
+    if not figures:
+        return None
+    # Match matplotlib's "current figure is the last one created" rule.
+    from generic_grader.sandbox.figure_facade import SerializedFigure
+
+    return SerializedFigure(figures[-1]).get_axes()
+
+
 def get_current_axes(test):
     """Find and return a list of axes in the current figure."""
 
-    # Get the axes from the current figure (creates figure if none exists).
-    axes_list = plt.gcf().get_axes()
+    axes_list = _sandbox_axes_for(test)
+    if axes_list is None:
+        # Get the axes from the current figure (creates figure if none exists).
+        axes_list = plt.gcf().get_axes()
 
     if not axes_list:
         # Axes list is empty.
@@ -195,8 +229,8 @@ def get_x_tick_labels(test):
     """Find and return the x tick labels of the plot."""
     ax = get_current_axes(test)[0]
 
-    # Force pyplot to produce the labels
-    plt.gcf().canvas.draw()
+    # Force pyplot to produce the labels (no-op in sandbox mode).
+    _draw_current_figure(test)
 
     return [label.get_text() for label in ax.get_xticklabels()]
 
@@ -205,8 +239,8 @@ def get_y_tick_labels(test):
     """Find and return the y tick labels of the plot."""
     ax = get_current_axes(test)[0]
 
-    # Force pyplot to produce the labels
-    plt.gcf().canvas.draw()
+    # Force pyplot to produce the labels (no-op in sandbox mode).
+    _draw_current_figure(test)
 
     return [label.get_text() for label in ax.get_yticklabels()]
 
@@ -224,7 +258,7 @@ def get_y_label(test):
 def get_grid_lines(test):
     """Find and return the visible grid lines of the current axes as a list of
     line tuples of vertex tuples."""
-    plt.gcf().canvas.draw()
+    _draw_current_figure(test)
 
     axes = get_current_axes(test)[0]
     x_gridlines = axes.get_xaxis().get_gridlines()

--- a/src/generic_grader/utils/user.py
+++ b/src/generic_grader/utils/user.py
@@ -316,8 +316,22 @@ class __User__:
         # `self.module` is set on subclasses (RefUser / SubUser).
         if self.obj is not SANDBOX_OBJ_SENTINEL and self.obj is not None:
             # Defensive: the only legitimate way to get into the
-            # sandbox call path is via the sandbox import path.
-            pass  # pragma: no cover - defensive sanity check
+            # sandbox call path is via the sandbox import path, which
+            # stamps ``self.obj`` with ``SANDBOX_OBJ_SENTINEL``.  If a
+            # caller has somehow bypassed that (e.g. tests stubbing
+            # ``self.obj`` directly), the call still goes through to
+            # the sandbox because that's what ``Options.use_sandbox``
+            # asked for, but the stamped ``self.obj`` is ignored.  Warn
+            # so misuse shows up in test logs.
+            import warnings
+
+            warnings.warn(
+                "_sandbox_call_obj invoked with self.obj set to a non-sentinel "
+                "value -- the sandbox path discards self.obj and re-resolves "
+                "the target inside the worker. This usually indicates the "
+                "sandbox import path was bypassed.",
+                stacklevel=2,
+            )
 
         msg = False
         call_str = make_call_str(o.obj_name, o.args, o.kwargs)

--- a/src/generic_grader/utils/user.py
+++ b/src/generic_grader/utils/user.py
@@ -15,7 +15,7 @@ from generic_grader.utils.exceptions import (
     handle_error,
     safe_exception_type,
 )
-from generic_grader.utils.importer import Importer
+from generic_grader.utils.importer import SANDBOX_OBJ_SENTINEL, Importer
 from generic_grader.utils.options import Options
 from generic_grader.utils.patches import custom_stack
 
@@ -239,6 +239,9 @@ class __User__:
         if o.log_limit:
             self.log.log_limit = o.log_limit
 
+        if o.use_sandbox:
+            return self._sandbox_call_obj()
+
         msg = False
         call_str = make_call_str(o.obj_name, o.args, o.kwargs)
         error_msg = "\n" + self.wrapper.fill(
@@ -283,6 +286,110 @@ class __User__:
             print(self.log.getvalue())
 
         return self.returned_values
+
+    # ------------------------------------------------------------------
+    # Sandbox path (Layer 3, gated on Options.use_sandbox)
+    # ------------------------------------------------------------------
+
+    def _sandbox_call_obj(self):
+        """Sandbox-backed equivalent of `call_obj`.
+
+        Runs the student call in a fresh isolate worker, then replays
+        the worker's events into this user's existing `LogIO` and
+        `interactions` so downstream helpers (`read_log_line`,
+        `format_log`, `get_value`, …) see the same data they would in
+        the legacy in-process path.
+
+        Sentinel check
+        --------------
+        `self.obj` should be `SANDBOX_OBJ_SENTINEL` here (set by
+        `Importer._sandbox_import_obj`).  We don't strictly require it
+        -- tests may stub `self.obj` directly -- but the check guards
+        against accidentally mixing the two paths.
+        """
+        from generic_grader.sandbox.integration import (
+            classify_call_outcome,
+            sandbox_call_obj,
+        )
+
+        o = self.options
+        # `self.module` is set on subclasses (RefUser / SubUser).
+        if self.obj is not SANDBOX_OBJ_SENTINEL and self.obj is not None:
+            # Defensive: the only legitimate way to get into the
+            # sandbox call path is via the sandbox import path.
+            pass  # pragma: no cover - defensive sanity check
+
+        msg = False
+        call_str = make_call_str(o.obj_name, o.args, o.kwargs)
+        error_msg = "\n" + self.wrapper.fill(
+            f"Your `{o.obj_name}` malfunctioned"
+            + f" when called as `{call_str}`"
+            + ((o.entries) and f" with entries {o.entries}." or ".")
+        )
+
+        result = sandbox_call_obj(self.module, o)
+        # Replay the worker's log into this user's LogIO so the existing
+        # downstream helpers see the same characters they would in the
+        # in-process path.  `interactions[0]` is always 0 (start of log);
+        # the integration module reconstructs subsequent offsets.
+        if result.log:
+            self.log.write(result.log)
+        self.interactions = list(result.interactions)
+        if result.return_non_serializable:
+            # Mirror the legacy behavior of capturing whatever the
+            # callable returned; for non-JSON-safe returns we expose
+            # the repr string so downstream comparisons can still
+            # inspect it (e.g. via `assertEqual(user.returned_values,
+            # "<MyObj>")`).
+            self.returned_values = result.return_repr
+        else:
+            self.returned_values = result.return_value
+
+        outcome = classify_call_outcome(result)
+        if outcome is None:
+            return self.returned_values
+
+        self.test.failureException = safe_exception_type(outcome)
+        msg = self._format_sandbox_call_failure(outcome, result, error_msg)
+
+        if msg:
+            log = self.log.getvalue()
+            if log:
+                msg += self.format_log()
+            self.test.fail(msg)
+
+        if o.debug:
+            print(self.log.getvalue())
+
+        return self.returned_values  # pragma: no cover - unreachable after fail
+
+    def _format_sandbox_call_failure(self, outcome, result, error_msg):
+        """Format a call-phase sandbox failure as a student message.
+
+        ExtraEntriesError gets the same "program ended before user
+        finished entering input" message as the legacy path.  Anything
+        else gets a synthetic traceback derived from the worker's
+        structured exception chain, so the student sees the same
+        information they'd see from an in-process exception.
+        """
+        if outcome is ExtraEntriesError:
+            return (
+                error_msg
+                + "\n\nHint:\n"
+                + self.wrapper.fill(
+                    "Your program ended before the user finished entering input."
+                )
+            )
+        # Build a traceback-style message from the worker's chain.
+        chain = result.exception or []
+        head = chain[0] if chain else {"type": outcome.__name__, "message": ""}
+        tb_text = head.get("traceback") or ""
+        formatted_traceback = (
+            ("Traceback (most recent call last):\n" + tb_text) if tb_text else ""
+        ) + f"{head.get('type', outcome.__name__)}: {head.get('message', '')}\n"
+        from generic_grader.utils.exceptions import indent
+
+        return indent(error_msg + "\n\n" + formatted_traceback)
 
 
 class RefUser(__User__):

--- a/src/generic_grader/utils/user.py
+++ b/src/generic_grader/utils/user.py
@@ -344,6 +344,12 @@ class __User__:
             self.returned_values = result.return_repr
         else:
             self.returned_values = result.return_value
+        # Hand any serialized figures off to the test so plot helpers
+        # (utils/plot.py) can read them via the host-side facade.  The
+        # legacy path leaves `plt.gcf()` populated for the same
+        # purpose; this is the sandbox equivalent.
+        if result.figures:
+            self.test._sandbox_figures = list(result.figures)
 
         outcome = classify_call_outcome(result)
         if outcome is None:

--- a/tests/sandbox/test_figure_facade.py
+++ b/tests/sandbox/test_figure_facade.py
@@ -1,0 +1,432 @@
+"""Round-trip tests for the host-side serialized-figure facade.
+
+The strategy: build a real ``matplotlib`` figure, snapshot every value
+that ``generic_grader.utils.plot`` would extract from it via the live
+API, then serialize the figure to a dict (the same dict the sandbox
+worker would ship), hand the dict to the facade, and verify every
+plot helper produces the same value when it reads through the facade.
+
+This pins the contract that the serialized format + facade together
+reproduce the live-matplotlib API surface used by the grader.
+"""
+
+from __future__ import annotations
+
+import datetime
+import unittest
+
+import matplotlib.pyplot as plt
+import pytest
+
+from generic_grader.sandbox.figure_facade import SerializedAxes, SerializedFigure
+from generic_grader.sandbox.figure_serializer import (
+    serialize_current_figures,
+    serialize_figure,
+)
+from generic_grader.utils.plot import (
+    get_bar_widths,
+    get_current_axes,
+    get_grid_lines,
+    get_legend,
+    get_line_colors,
+    get_number_bars,
+    get_number_lines,
+    get_pie_wedge_angles,
+    get_pie_wedge_colors,
+    get_pie_wedge_labels,
+    get_property,
+    get_spine_positions,
+    get_spine_visibility,
+    get_title,
+    get_x_data,
+    get_x_label,
+    get_x_limits,
+    get_x_tick_labels,
+    get_x_time_data,
+    get_xy_data,
+    get_y_data,
+    get_y_label,
+    get_y_limits,
+    get_y_tick_labels,
+)
+
+
+class MockTest(unittest.TestCase):
+    """Test stub that lets ``test.fail`` raise like a real test."""
+
+
+@pytest.fixture
+def line_test():
+    """Build a line plot, snapshot values live, then re-attach via the facade.
+
+    The fixture yields a tuple ``(test_live, test_sandbox)`` where both
+    expose the same figure's data, but ``test_live`` reads via the
+    live ``plt.gcf()`` and ``test_sandbox`` reads via the serialized
+    facade attached to ``test._sandbox_figures``.
+    """
+    fig, ax = plt.subplots()
+    ax.plot(range(5), [v * 2 for v in range(5)], label="Line", color="#4A90E2")
+    ax.set_xlim(-1, 6)
+    ax.set_ylim(-1, 11)
+    ax.set_xticks(range(5), [f"x{x}" for x in range(5)])
+    ax.set_yticks(range(0, 11, 2), [f"y{y}" for y in range(0, 11, 2)])
+    ax.set_xlabel("X")
+    ax.set_ylabel("Y")
+    ax.set_title("Hello")
+    ax.legend()
+    ax.spines["top"].set_visible(False)
+    ax.spines["bottom"].set_position("zero")
+    serialized = serialize_figure(fig)
+
+    test_live = MockTest()
+    test_sandbox = MockTest()
+    test_sandbox._sandbox_figures = [serialized]
+    yield test_live, test_sandbox
+    plt.close(fig)
+
+
+def test_facade_number_of_lines(line_test):
+    live, sandbox = line_test
+    assert get_number_lines(sandbox) == get_number_lines(live) == 1
+
+
+def test_facade_line_colors(line_test):
+    live, sandbox = line_test
+    assert get_line_colors(sandbox) == get_line_colors(live)
+
+
+def test_facade_xy_data(line_test):
+    live, sandbox = line_test
+    live_xy = get_xy_data(live)
+    sandbox_xy = get_xy_data(sandbox)
+    assert list(sandbox_xy.x) == list(live_xy.x)
+    assert list(sandbox_xy.y) == list(live_xy.y)
+
+
+def test_facade_x_y_data_separately(line_test):
+    live, sandbox = line_test
+    assert get_x_data(sandbox) == get_x_data(live)
+    assert get_y_data(sandbox) == get_y_data(live)
+
+
+def test_facade_x_data_missing_index_fails(line_test):
+    _, sandbox = line_test
+    with pytest.raises(AssertionError):
+        get_x_data(sandbox, index=5)
+
+
+def test_facade_y_data_missing_index_fails(line_test):
+    _, sandbox = line_test
+    with pytest.raises(AssertionError):
+        get_y_data(sandbox, index=5)
+
+
+def test_facade_limits_and_labels(line_test):
+    live, sandbox = line_test
+    assert get_x_limits(sandbox) == get_x_limits(live)
+    assert get_y_limits(sandbox) == get_y_limits(live)
+    assert get_x_label(sandbox) == get_x_label(live)
+    assert get_y_label(sandbox) == get_y_label(live)
+    assert get_title(sandbox) == get_title(live)
+
+
+def test_facade_tick_labels(line_test):
+    live, sandbox = line_test
+    assert get_x_tick_labels(sandbox) == get_x_tick_labels(live)
+    assert get_y_tick_labels(sandbox) == get_y_tick_labels(live)
+
+
+def test_facade_legend(line_test):
+    live, sandbox = line_test
+    assert get_legend(sandbox) == get_legend(live)
+
+
+def test_facade_spine_visibility(line_test):
+    live, sandbox = line_test
+    assert get_spine_visibility(sandbox) == get_spine_visibility(live)
+
+
+def test_facade_spine_positions(line_test):
+    live, sandbox = line_test
+    # Spine positions can be either strings ('zero') or 2-tuples; both
+    # forms round-trip exactly through the facade.
+    assert get_spine_positions(sandbox) == get_spine_positions(live)
+
+
+def test_facade_get_property_dispatch(line_test):
+    """``get_property`` is the single entry point used by image tests."""
+    live, sandbox = line_test
+    for prop in ("title", "x label", "y label", "x limits", "y limits"):
+        assert get_property(sandbox, prop, {}) == get_property(live, prop, {})
+
+
+# ---------------------------------------------------------------------------
+# Bar chart facade
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bar_test():
+    fig, ax = plt.subplots()
+    ax.bar([0, 1, 2], [3, 5, 7])
+    serialized = serialize_figure(fig)
+    live = MockTest()
+    sandbox = MockTest()
+    sandbox._sandbox_figures = [serialized]
+    yield live, sandbox
+    plt.close(fig)
+
+
+def test_facade_bar_count_and_widths(bar_test):
+    live, sandbox = bar_test
+    assert get_number_bars(sandbox) == get_number_bars(live)
+    assert get_bar_widths(sandbox) == get_bar_widths(live)
+
+
+def test_facade_bar_x_y_data(bar_test):
+    live, sandbox = bar_test
+    assert get_x_data(sandbox) == get_x_data(live)
+    assert get_y_data(sandbox) == get_y_data(live)
+
+
+def test_facade_empty_bar_widths_when_no_bars():
+    """A non-bar axes facade reports zero bars and triggers the legacy fail."""
+    fig, ax = plt.subplots()
+    ax.plot([0], [0])
+    serialized = serialize_figure(fig)
+    sandbox = MockTest()
+    sandbox._sandbox_figures = [serialized]
+    with pytest.raises(AssertionError):
+        get_number_bars(sandbox)
+    with pytest.raises(AssertionError):
+        get_bar_widths(sandbox)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Pie chart facade
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pie_test():
+    fig, ax = plt.subplots()
+    ax.pie([1, 2, 3], labels=["A", "B", "C"], colors=["red", "green", "blue"])
+    serialized = serialize_figure(fig)
+    live = MockTest()
+    sandbox = MockTest()
+    sandbox._sandbox_figures = [serialized]
+    yield live, sandbox
+    plt.close(fig)
+
+
+def test_facade_pie_labels_colors_angles(pie_test):
+    live, sandbox = pie_test
+    assert get_pie_wedge_labels(sandbox) == get_pie_wedge_labels(live)
+    assert get_pie_wedge_colors(sandbox) == get_pie_wedge_colors(live)
+    assert get_pie_wedge_angles(sandbox) == get_pie_wedge_angles(live)
+
+
+def test_facade_pie_missing_wedges_fails():
+    """Asking for pie wedges on a line plot fails like the live path."""
+    fig, ax = plt.subplots()
+    ax.plot([0], [0])
+    serialized = serialize_figure(fig)
+    sandbox = MockTest()
+    sandbox._sandbox_figures = [serialized]
+    with pytest.raises(AssertionError):
+        get_pie_wedge_labels(sandbox)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Grid lines + time data
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def grid_test():
+    fig, ax = plt.subplots()
+    ax.plot(range(5), range(5))
+    ax.grid(True)
+    serialized = serialize_figure(fig)
+    live = MockTest()
+    sandbox = MockTest()
+    sandbox._sandbox_figures = [serialized]
+    yield live, sandbox
+    plt.close(fig)
+
+
+def test_facade_grid_lines_present(grid_test):
+    _, sandbox = grid_test
+    grid = get_grid_lines(sandbox)
+    # Live mpl gridlines are sometimes drawn outside the data window;
+    # the worker has already filtered to the visible window, so we
+    # just require that at least one gridline made it through.
+    assert isinstance(grid, list)
+    assert all(isinstance(line, tuple) for line in grid)
+
+
+def test_facade_x_time_data():
+    fig, ax = plt.subplots()
+    dates = [datetime.date(2024, 1, d) for d in range(1, 4)]
+    ax.bar(dates, [1, 2, 3])
+    serialized = serialize_figure(fig)
+    live = MockTest()
+    sandbox = MockTest()
+    sandbox._sandbox_figures = [serialized]
+    assert get_x_time_data(sandbox) == get_x_time_data(live)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Direct facade-class behaviors
+# ---------------------------------------------------------------------------
+
+
+def test_serialized_figure_with_no_axes_returns_empty():
+    sf = SerializedFigure({"axes": []})
+    assert sf.get_axes() == []
+
+
+def test_serialized_axes_default_values():
+    """Missing dict keys fall back to sensible defaults."""
+    ax = SerializedAxes({})
+    assert ax.title.get_text() == ""
+    assert ax.get_xlabel() == ""
+    assert ax.get_ylabel() == ""
+    assert ax.get_xlim() == (0.0, 1.0)
+    assert ax.get_ylim() == (0.0, 1.0)
+    assert ax.get_xticklabels() == []
+    assert ax.get_yticklabels() == []
+    assert ax.get_lines() == []
+    assert ax.containers == []
+    assert ax.patches == []
+    assert ax.get_legend() is None
+    assert ax.spines == {}
+    # Both axes share the full gridline list so each helper can re-window.
+    assert ax.get_xaxis().get_gridlines() == []
+    assert ax.get_yaxis().get_gridlines() == []
+
+
+def test_serialized_axes_line_with_named_color():
+    """When ``color_name`` is set, the facade returns it directly."""
+    ax = SerializedAxes(
+        {
+            "lines": [
+                {
+                    "xdata": [0.0],
+                    "ydata": [0.0],
+                    "color_name": "red",
+                    "color_rgba": None,
+                }
+            ]
+        }
+    )
+    assert ax.get_lines()[0].get_color() == "red"
+
+
+def test_serialized_axes_line_without_named_color():
+    ax = SerializedAxes(
+        {
+            "lines": [
+                {
+                    "xdata": [0.0, 1.0],
+                    "ydata": [0.0, 2.0],
+                    "color_name": None,
+                    "color_rgba": [0.1, 0.2, 0.3, 0.5],
+                }
+            ]
+        }
+    )
+    line = ax.get_lines()[0]
+    assert line.get_xdata() == [0.0, 1.0]
+    assert line.get_ydata() == [0.0, 2.0]
+    assert line.get_color() == (0.1, 0.2, 0.3, 0.5)
+
+
+def test_serialized_axes_line_with_no_color_at_all():
+    """Both ``color_name`` and ``color_rgba`` missing -> opaque black."""
+    ax = SerializedAxes({"lines": [{"xdata": [], "ydata": []}]})
+    line = ax.get_lines()[0]
+    assert line.get_color() == (0.0, 0.0, 0.0, 1.0)
+
+
+def test_serialized_axes_spine_position_string_form():
+    ax = SerializedAxes(
+        {
+            "spine_visibility": {"bottom": True},
+            "spine_positions": {"bottom": "zero"},
+        }
+    )
+    spine = ax.spines["bottom"]
+    assert spine.get_position() == "zero"
+    assert spine.get_visible() is True
+    assert spine.get_linewidth() == 1.0
+    assert spine.get_edgecolor()[3] == 1.0
+
+
+def test_serialized_axes_spine_invisible():
+    ax = SerializedAxes(
+        {
+            "spine_visibility": {"top": False},
+            "spine_positions": {"top": ["data", 0.0]},
+        }
+    )
+    spine = ax.spines["top"]
+    assert spine.get_visible() is False
+    assert spine.get_linewidth() == 0.0
+    assert spine.get_edgecolor()[3] == 0.0
+
+
+def test_serialize_current_figures_into_facade_roundtrip():
+    """`serialize_current_figures` returns a list; the facade reads each."""
+    # Start from a clean slate so any stray figures left by prior tests
+    # don't leak into ``plt.get_fignums()``.
+    plt.close("all")
+    fig1, ax1 = plt.subplots()
+    ax1.plot([0, 1], [0, 1])
+    ax1.set_title("First")
+    fig2, ax2 = plt.subplots()
+    ax2.plot([2, 3], [2, 3])
+    ax2.set_title("Second")
+    serialized = serialize_current_figures()
+    assert len(serialized) == 2
+    # `get_current_axes` reads the last figure, matching plt.gcf() rules.
+    sandbox = MockTest()
+    sandbox._sandbox_figures = serialized
+    assert get_title(sandbox) == "Second"
+
+
+# ---------------------------------------------------------------------------
+# Routing: live path is unaffected when no sandbox figures are attached
+# ---------------------------------------------------------------------------
+
+
+def test_live_path_unaffected_without_sandbox_attribute():
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+    ax.set_title("Live")
+    live = MockTest()
+    # No `_sandbox_figures` attribute -> live plt.gcf() path is used.
+    assert get_title(live) == "Live"
+    plt.close(fig)
+
+
+def test_empty_sandbox_figures_falls_through_to_live():
+    """An empty list shouldn't be treated as 'sandbox mode'."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+    ax.set_title("Fallback")
+    live = MockTest()
+    live._sandbox_figures = []
+    assert get_title(live) == "Fallback"
+    plt.close(fig)
+
+
+def test_sandbox_axes_with_no_axes_fails_test():
+    """An empty axes list in the sandbox payload calls test.fail."""
+    sandbox = MockTest()
+    sandbox._sandbox_figures = [{"axes": []}]
+    with pytest.raises(AssertionError):
+        get_current_axes(sandbox)

--- a/tests/sandbox/test_figure_facade.py
+++ b/tests/sandbox/test_figure_facade.py
@@ -267,6 +267,61 @@ def test_facade_grid_lines_present(grid_test):
     assert all(isinstance(line, tuple) for line in grid)
 
 
+def test_facade_grid_lines_no_double_count_with_overlapping_limits():
+    """Regression for the original single-list ``grid_lines`` schema.
+
+    When ``xlim`` and ``ylim`` overlap, each gridline's first vertex
+    satisfies both window filters in ``utils.plot.get_grid_lines``.
+    The split-by-axis schema must produce exactly the same count as
+    the live matplotlib path.
+    """
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2], [0, 1, 2])
+    ax.set_xticks([0, 1, 2])
+    ax.set_yticks([0, 1, 2])
+    ax.set_xlim(-1, 3)
+    ax.set_ylim(-1, 3)
+    ax.grid(True)
+    sandbox = MockTest()
+    sandbox._sandbox_figures = [serialize_figure(fig)]
+    # Live count taken directly from the figure we just serialized.
+    live_count = len(get_grid_lines_from_live_ax(ax))
+    assert len(get_grid_lines(sandbox)) == live_count
+    plt.close(fig)
+
+
+def get_grid_lines_from_live_ax(ax):
+    """Replicate ``utils.plot.get_grid_lines`` against a live ``Axes``."""
+    x_gl = ax.get_xaxis().get_gridlines()
+    y_gl = ax.get_yaxis().get_gridlines()
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    x_lines = [
+        tuple(map(tuple, g.get_path().vertices)) for g in x_gl if g.get_visible()
+    ]
+    y_lines = [
+        tuple(map(tuple, g.get_path().vertices)) for g in y_gl if g.get_visible()
+    ]
+    out = []
+    out.extend(line for line in x_lines if xmin <= line[0][0] <= xmax)
+    out.extend(line for line in y_lines if ymin <= line[0][1] <= ymax)
+    return out
+
+
+def test_facade_grid_lines_legacy_schema():
+    """Old ``grid_lines`` field must still be readable (backward compat)."""
+    legacy = SerializedAxes(
+        {
+            "xlim": [0.0, 10.0],
+            "ylim": [0.0, 10.0],
+            "grid_lines": [[[1.0, 0.0], [1.0, 10.0]], [[0.0, 1.0], [10.0, 1.0]]],
+        }
+    )
+    # Both axes return the full legacy list (the old behavior).
+    assert len(legacy.get_xaxis().get_gridlines()) == 2
+    assert len(legacy.get_yaxis().get_gridlines()) == 2
+
+
 def test_facade_x_time_data():
     fig, ax = plt.subplots()
     dates = [datetime.date(2024, 1, d) for d in range(1, 4)]
@@ -304,7 +359,8 @@ def test_serialized_axes_default_values():
     assert ax.patches == []
     assert ax.get_legend() is None
     assert ax.spines == {}
-    # Both axes share the full gridline list so each helper can re-window.
+    # Each axis returns its own list -- the serialized schema keeps
+    # x-axis (vertical) and y-axis (horizontal) gridlines separate.
     assert ax.get_xaxis().get_gridlines() == []
     assert ax.get_yaxis().get_gridlines() == []
 

--- a/tests/sandbox/test_figure_serializer.py
+++ b/tests/sandbox/test_figure_serializer.py
@@ -323,11 +323,14 @@ def test_serialize_legend_absent_is_none(bar_figure):
 
 def test_serialize_captures_grid_lines(line_figure):
     data = serialize_figure(line_figure)
-    grid = data["axes"][0]["grid_lines"]
-    # The fixture enabled grid; we expect at least one visible grid line.
-    assert len(grid) >= 1
+    x_grid = data["axes"][0]["x_grid_lines"]
+    y_grid = data["axes"][0]["y_grid_lines"]
+    # The fixture enabled grid; we expect at least one visible grid line
+    # on each axis.
+    assert len(x_grid) >= 1
+    assert len(y_grid) >= 1
     # Each grid line is a list of [x, y] vertex pairs.
-    for line in grid:
+    for line in x_grid + y_grid:
         assert isinstance(line, list)
         for vertex in line:
             assert len(vertex) == 2
@@ -336,9 +339,10 @@ def test_serialize_captures_grid_lines(line_figure):
 
 def test_serialize_grid_lines_empty_when_grid_off(bar_figure):
     data = serialize_figure(bar_figure)
-    # bar_figure didn't enable grid -- grid_lines must be empty
-    # (matching plot.get_grid_lines which filters on visibility).
-    assert data["axes"][0]["grid_lines"] == []
+    # bar_figure didn't enable grid -- both grid line lists must be
+    # empty (matching plot.get_grid_lines which filters on visibility).
+    assert data["axes"][0]["x_grid_lines"] == []
+    assert data["axes"][0]["y_grid_lines"] == []
 
 
 def test_serialize_grid_lines_filtered_to_axes_window():
@@ -349,14 +353,66 @@ def test_serialize_grid_lines_filtered_to_axes_window():
     ax.set_ylim(4.5, 5.5)
     ax.grid(True)
     data = serialize_figure(fig)
-    grid = data["axes"][0]["grid_lines"]
-    # Every reported gridline must have at least one vertex inside the
-    # axes window on the relevant axis.
-    for line in grid:
-        xs = [v[0] for v in line]
-        ys = [v[1] for v in line]
-        in_window = any(1.5 <= x <= 2.5 for x in xs) or any(4.5 <= y <= 5.5 for y in ys)
-        assert in_window
+    # x-axis gridlines must have first vertex inside ``xlim``.
+    for line in data["axes"][0]["x_grid_lines"]:
+        assert 1.5 <= line[0][0] <= 2.5
+    # y-axis gridlines must have first vertex inside ``ylim``.
+    for line in data["axes"][0]["y_grid_lines"]:
+        assert 4.5 <= line[0][1] <= 5.5
+
+
+def test_serialize_grid_lines_match_live_count_with_overlapping_limits():
+    """Regression: the previous single-list schema double-counted
+    gridlines when ``xlim`` and ``ylim`` overlapped (each line's first
+    vertex satisfied both filters).  The split-by-axis schema must
+    produce exactly as many lines as ``utils.plot.get_grid_lines`` would.
+    """
+    from generic_grader.sandbox.figure_facade import SerializedFigure
+    from generic_grader.utils.plot import get_grid_lines
+
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2], [0, 1, 2])
+    ax.set_xticks([0, 1, 2])
+    ax.set_yticks([0, 1, 2])
+    ax.set_xlim(-1, 3)
+    ax.set_ylim(-1, 3)
+    ax.grid(True)
+
+    class _T:
+        pass
+
+    live = _T()
+    live._sandbox_figures = None
+    sandbox = _T()
+    sandbox._sandbox_figures = [serialize_figure(fig)]
+    # We're inside ``plt.show``-less land, so plug the live figure
+    # into the helper via the explicit axes.
+    facade_axes = SerializedFigure(sandbox._sandbox_figures[0]).get_axes()
+    facade_x = facade_axes[0].get_xaxis().get_gridlines()
+    facade_y = facade_axes[0].get_yaxis().get_gridlines()
+    live_x = ax.get_xaxis().get_gridlines()
+    live_y = ax.get_yaxis().get_gridlines()
+    # The serializer drops invisible gridlines and ones outside the
+    # axes window -- the live arrays we compare against have already
+    # had visibility/window filtering applied identically by the
+    # serializer, so the counts should match.
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    expected_x = [
+        g
+        for g in live_x
+        if g.get_visible() and xmin <= g.get_path().vertices[0][0] <= xmax
+    ]
+    expected_y = [
+        g
+        for g in live_y
+        if g.get_visible() and ymin <= g.get_path().vertices[0][1] <= ymax
+    ]
+    assert len(facade_x) == len(expected_x)
+    assert len(facade_y) == len(expected_y)
+    # And via the public plot helper that callers actually use:
+    expected_total = len(expected_x) + len(expected_y)
+    assert len(get_grid_lines(sandbox)) == expected_total
 
 
 # ---------------------------------------------------------------------------
@@ -435,7 +491,8 @@ def test_serialize_figure_with_empty_axes():
         "bar_values",
         "wedges",
         "legend",
-        "grid_lines",
+        "x_grid_lines",
+        "y_grid_lines",
         "spine_visibility",
         "spine_positions",
     ):

--- a/tests/sandbox/test_figure_serializer.py
+++ b/tests/sandbox/test_figure_serializer.py
@@ -1,0 +1,619 @@
+"""Tests for the matplotlib figure serializer.
+
+The serializer produces a JSON-safe dict capturing every property the
+existing `utils/plot.py` extracts from a live `plt.gcf()`. The plan
+for commit 6 is to teach `utils/plot.py` to read from this dict so
+the grader no longer needs the original Figure object after the
+sandbox subprocess exits.
+
+These tests build representative figures (line, bar, pie, mixed,
+multi-line, multi-axes), serialize them, and assert the resulting
+dict supports the full set of properties.
+"""
+
+import json
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+from generic_grader.sandbox.figure_serializer import serialize_figure  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _close_all_figures():
+    """Guarantee a clean slate for every test."""
+    plt.close("all")
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def line_figure():
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [4, 5, 6], color="red", label="series A")
+    ax.plot([1, 2, 3], [7, 8, 9], color="blue", label="series B")
+    ax.set_xlabel("time")
+    ax.set_ylabel("value")
+    ax.set_title("Two lines")
+    ax.set_xlim(0, 4)
+    ax.set_ylim(0, 10)
+    ax.legend()
+    ax.grid(True)
+    return fig
+
+
+@pytest.fixture
+def bar_figure():
+    fig, ax = plt.subplots()
+    ax.bar([1, 2, 3], [10, 20, 30], width=0.6)
+    ax.set_xlabel("category")
+    ax.set_ylabel("count")
+    ax.set_title("A bar chart")
+    return fig
+
+
+@pytest.fixture
+def pie_figure():
+    fig, ax = plt.subplots()
+    ax.pie([30, 45, 25], labels=["A", "B", "C"], colors=["red", "green", "blue"])
+    ax.set_title("Pie")
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Smoke / JSON safety
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_returns_a_dict(line_figure):
+    data = serialize_figure(line_figure)
+    assert isinstance(data, dict)
+
+
+def test_serialize_is_json_safe(line_figure):
+    data = serialize_figure(line_figure)
+    # Round-trip through JSON to be sure nothing slipped in as a
+    # numpy scalar or matplotlib object.
+    text = json.dumps(data)
+    restored = json.loads(text)
+    assert restored == data
+
+
+def test_serialize_is_json_safe_bar(bar_figure):
+    data = serialize_figure(bar_figure)
+    assert json.loads(json.dumps(data)) == data
+
+
+def test_serialize_is_json_safe_pie(pie_figure):
+    data = serialize_figure(pie_figure)
+    assert json.loads(json.dumps(data)) == data
+
+
+def test_serialize_format_version_present(line_figure):
+    data = serialize_figure(line_figure)
+    assert data["format"] == "matplotlib-figure"
+    assert data["version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Axes structure
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_records_one_axes_per_subplot(line_figure):
+    data = serialize_figure(line_figure)
+    assert len(data["axes"]) == 1
+
+
+def test_serialize_records_multiple_axes():
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+    ax1.plot([1, 2], [3, 4])
+    ax2.bar([1, 2], [5, 6])
+    data = serialize_figure(fig)
+    assert len(data["axes"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Title / labels / limits
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_captures_title(line_figure):
+    data = serialize_figure(line_figure)
+    assert data["axes"][0]["title"] == "Two lines"
+
+
+def test_serialize_captures_x_label(line_figure):
+    data = serialize_figure(line_figure)
+    assert data["axes"][0]["xlabel"] == "time"
+
+
+def test_serialize_captures_y_label(line_figure):
+    data = serialize_figure(line_figure)
+    assert data["axes"][0]["ylabel"] == "value"
+
+
+def test_serialize_captures_x_limits(line_figure):
+    data = serialize_figure(line_figure)
+    xlim = data["axes"][0]["xlim"]
+    assert xlim == [0.0, 4.0]
+
+
+def test_serialize_captures_y_limits(line_figure):
+    data = serialize_figure(line_figure)
+    ylim = data["axes"][0]["ylim"]
+    assert ylim == [0.0, 10.0]
+
+
+def test_serialize_captures_tick_labels(line_figure):
+    data = serialize_figure(line_figure)
+    # ax.get_xticklabels() only has text after a draw; the serializer
+    # is responsible for forcing the draw, exactly like plot.py does.
+    xticks = data["axes"][0]["xticklabels"]
+    yticks = data["axes"][0]["yticklabels"]
+    assert isinstance(xticks, list) and all(isinstance(t, str) for t in xticks)
+    assert isinstance(yticks, list) and all(isinstance(t, str) for t in yticks)
+    # The line plot covers x=1..3 with xlim=0..4 so there must be
+    # at least one visible tick.
+    assert any(t.strip() for t in xticks)
+
+
+# ---------------------------------------------------------------------------
+# Lines
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_captures_line_count(line_figure):
+    data = serialize_figure(line_figure)
+    assert len(data["axes"][0]["lines"]) == 2
+
+
+def test_serialize_captures_line_xdata_and_ydata(line_figure):
+    data = serialize_figure(line_figure)
+    line0 = data["axes"][0]["lines"][0]
+    assert line0["xdata"] == [1.0, 2.0, 3.0]
+    assert line0["ydata"] == [4.0, 5.0, 6.0]
+
+
+def test_serialize_captures_named_color_when_available(line_figure):
+    data = serialize_figure(line_figure)
+    line0 = data["axes"][0]["lines"][0]
+    line1 = data["axes"][0]["lines"][1]
+    # Matches the existing plot.get_line_colors behavior: the named-color
+    # mapping is sorted alphabetically and the first match wins. 'r' and
+    # 'b' (the single-letter aliases) sort before 'red' / 'blue'.
+    assert line0["color_name"] in ("r", "red")
+    assert line1["color_name"] in ("b", "blue")
+
+
+def test_serialize_falls_back_to_rgba_for_unnamed_colors():
+    fig, ax = plt.subplots()
+    # Pick an odd hex color that has no named equivalent.
+    ax.plot([1, 2], [3, 4], color="#abcdef")
+    data = serialize_figure(fig)
+    line = data["axes"][0]["lines"][0]
+    assert line["color_name"] is None
+    assert line["color_rgba"] is not None
+    assert len(line["color_rgba"]) == 4
+    assert all(isinstance(c, float) for c in line["color_rgba"])
+
+
+def test_serialize_x_time_data_uses_dates():
+    """Bar/line plots can use matplotlib date numbers on the x axis."""
+    import datetime as dt
+
+    fig, ax = plt.subplots()
+    dates = [dt.date(2024, 1, d) for d in (1, 2, 3)]
+    ax.plot(dates, [10, 20, 30])
+    data = serialize_figure(fig)
+    line = data["axes"][0]["lines"][0]
+    # xdata should be three float matplotlib date numbers; we don't
+    # convert here -- commit 6 will read x_time_data by passing each
+    # number through mpl.dates.num2date on the host.
+    assert len(line["xdata"]) == 3
+    assert all(isinstance(v, float) for v in line["xdata"])
+
+
+# ---------------------------------------------------------------------------
+# Bars
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_captures_bars(bar_figure):
+    data = serialize_figure(bar_figure)
+    bars = data["axes"][0]["bars"]
+    assert len(bars) == 3
+
+
+def test_serialize_captures_bar_widths(bar_figure):
+    data = serialize_figure(bar_figure)
+    widths = [b["width"] for b in data["axes"][0]["bars"]]
+    assert all(abs(w - 0.6) < 1e-9 for w in widths)
+
+
+def test_serialize_captures_bar_x_centers(bar_figure):
+    """x positions = left edge + width/2, matching plot.get_x_data behavior."""
+    data = serialize_figure(bar_figure)
+    centers = [b["x_center"] for b in data["axes"][0]["bars"]]
+    assert centers == [1.0, 2.0, 3.0]
+
+
+def test_serialize_captures_bar_values(bar_figure):
+    """`datavalues` is the canonical source for bar heights."""
+    data = serialize_figure(bar_figure)
+    values = data["axes"][0]["bar_values"]
+    assert values == [10.0, 20.0, 30.0]
+
+
+def test_serialize_line_axes_have_empty_bar_list(line_figure):
+    """A pure line plot has no bars, but the key must still be present."""
+    data = serialize_figure(line_figure)
+    assert data["axes"][0]["bars"] == []
+    assert data["axes"][0]["bar_values"] == []
+
+
+# ---------------------------------------------------------------------------
+# Pie wedges
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_captures_pie_wedges(pie_figure):
+    data = serialize_figure(pie_figure)
+    wedges = data["axes"][0]["wedges"]
+    assert len(wedges) == 3
+
+
+def test_serialize_captures_pie_wedge_labels(pie_figure):
+    data = serialize_figure(pie_figure)
+    labels = [w["label"] for w in data["axes"][0]["wedges"]]
+    assert labels == ["A", "B", "C"]
+
+
+def test_serialize_captures_pie_wedge_colors(pie_figure):
+    data = serialize_figure(pie_figure)
+    colors = [w["color_hex"] for w in data["axes"][0]["wedges"]]
+    # to_hex normalizes to lowercase 7-char (#rrggbb) or 9-char (#rrggbbaa)
+    assert colors[0].lower().startswith("#")
+    assert len(set(colors)) == 3
+
+
+def test_serialize_captures_pie_wedge_angles(pie_figure):
+    data = serialize_figure(pie_figure)
+    angles = [w["angle_degrees"] for w in data["axes"][0]["wedges"]]
+    # Pie chart angles should sum to 360 (proportional to 30/45/25).
+    assert abs(sum(angles) - 360.0) < 1e-3
+    # Each angle was rounded to 4 decimal places, matching plot.py.
+    for a in angles:
+        assert round(a, 4) == a
+
+
+def test_serialize_line_axes_have_empty_wedge_list(line_figure):
+    data = serialize_figure(line_figure)
+    assert data["axes"][0]["wedges"] == []
+
+
+# ---------------------------------------------------------------------------
+# Legend
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_captures_legend(line_figure):
+    data = serialize_figure(line_figure)
+    legend = data["axes"][0]["legend"]
+    assert legend == ["series A", "series B"]
+
+
+def test_serialize_legend_absent_is_none(bar_figure):
+    data = serialize_figure(bar_figure)
+    assert data["axes"][0]["legend"] is None
+
+
+# ---------------------------------------------------------------------------
+# Grid lines
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_captures_grid_lines(line_figure):
+    data = serialize_figure(line_figure)
+    grid = data["axes"][0]["grid_lines"]
+    # The fixture enabled grid; we expect at least one visible grid line.
+    assert len(grid) >= 1
+    # Each grid line is a list of [x, y] vertex pairs.
+    for line in grid:
+        assert isinstance(line, list)
+        for vertex in line:
+            assert len(vertex) == 2
+            assert all(isinstance(c, float) for c in vertex)
+
+
+def test_serialize_grid_lines_empty_when_grid_off(bar_figure):
+    data = serialize_figure(bar_figure)
+    # bar_figure didn't enable grid -- grid_lines must be empty
+    # (matching plot.get_grid_lines which filters on visibility).
+    assert data["axes"][0]["grid_lines"] == []
+
+
+def test_serialize_grid_lines_filtered_to_axes_window():
+    """grid_lines outside xlim/ylim are dropped, exactly like plot.py."""
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [4, 5, 6])
+    ax.set_xlim(1.5, 2.5)
+    ax.set_ylim(4.5, 5.5)
+    ax.grid(True)
+    data = serialize_figure(fig)
+    grid = data["axes"][0]["grid_lines"]
+    # Every reported gridline must have at least one vertex inside the
+    # axes window on the relevant axis.
+    for line in grid:
+        xs = [v[0] for v in line]
+        ys = [v[1] for v in line]
+        in_window = any(1.5 <= x <= 2.5 for x in xs) or any(4.5 <= y <= 5.5 for y in ys)
+        assert in_window
+
+
+# ---------------------------------------------------------------------------
+# Spines
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_captures_spine_visibility(line_figure):
+    data = serialize_figure(line_figure)
+    visibility = data["axes"][0]["spine_visibility"]
+    # Default matplotlib axes have all four spines visible.
+    assert visibility == {"left": True, "right": True, "top": True, "bottom": True}
+
+
+def test_serialize_reflects_spine_set_invisible():
+    fig, ax = plt.subplots()
+    ax.plot([1, 2], [3, 4])
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_linewidth(0)
+    data = serialize_figure(fig)
+    visibility = data["axes"][0]["spine_visibility"]
+    assert visibility["top"] is False
+    assert visibility["right"] is False
+    assert visibility["left"] is True
+    assert visibility["bottom"] is True
+
+
+def test_serialize_reflects_spine_alpha_zero():
+    fig, ax = plt.subplots()
+    ax.plot([1, 2], [3, 4])
+    ax.spines["left"].set_color((0.0, 0.0, 0.0, 0.0))
+    data = serialize_figure(fig)
+    assert data["axes"][0]["spine_visibility"]["left"] is False
+
+
+def test_serialize_captures_spine_positions():
+    fig, ax = plt.subplots()
+    ax.plot([1, 2], [3, 4])
+    ax.spines["left"].set_position(("data", 0.5))
+    ax.spines["bottom"].set_position("zero")
+    data = serialize_figure(fig)
+    positions = data["axes"][0]["spine_positions"]
+    # Position is reported as a 2-tuple [kind, value]. 'zero' is a
+    # string-style position which keeps the original string.
+    assert positions["left"] == ["data", 0.5]
+    assert positions["bottom"] == ["zero", 0.0] or positions["bottom"] == "zero"
+
+
+# ---------------------------------------------------------------------------
+# Empty / edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_figure_with_no_axes():
+    fig = plt.figure()
+    data = serialize_figure(fig)
+    # No axes still produces a well-formed dict with an empty list.
+    assert data["axes"] == []
+
+
+def test_serialize_figure_with_empty_axes():
+    fig, ax = plt.subplots()
+    data = serialize_figure(fig)
+    # Empty axes still produce all keys.
+    axes_data = data["axes"][0]
+    for key in (
+        "title",
+        "xlabel",
+        "ylabel",
+        "xlim",
+        "ylim",
+        "xticklabels",
+        "yticklabels",
+        "lines",
+        "bars",
+        "bar_values",
+        "wedges",
+        "legend",
+        "grid_lines",
+        "spine_visibility",
+        "spine_positions",
+    ):
+        assert key in axes_data
+
+
+def test_serialize_passes_numpy_arrays_through_safely():
+    """numpy arrays on either axis must become plain lists of floats."""
+    fig, ax = plt.subplots()
+    ax.plot(np.array([1, 2, 3]), np.array([4.5, 5.5, 6.5]))
+    data = serialize_figure(fig)
+    line = data["axes"][0]["lines"][0]
+    assert line["xdata"] == [1.0, 2.0, 3.0]
+    assert line["ydata"] == [4.5, 5.5, 6.5]
+    # No numpy types should survive into the dict.
+    for v in line["xdata"] + line["ydata"]:
+        assert isinstance(v, float) and not isinstance(v, np.floating)
+
+
+def test_serialize_handles_object_array_when_date2num_fails(monkeypatch):
+    """If date2num refuses an object array, fall back to per-element float()."""
+    import matplotlib as _mpl
+
+    fig, ax = plt.subplots()
+    # Plot something benign so we have a line to work with.
+    ax.plot([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+
+    def boom(values):
+        raise TypeError("refusing to convert")
+
+    monkeypatch.setattr(_mpl.dates, "date2num", boom)
+
+    # Replace the line's xdata with an object array containing a mix
+    # of float-convertible and non-convertible values so we exercise
+    # both branches of the fallback loop.
+    line = ax.get_lines()[0]
+    line.set_xdata(np.array([1.5, "oops", 3.5], dtype=object))
+    data = serialize_figure(fig)
+    xdata = data["axes"][0]["lines"][0]["xdata"]
+    # Two valid floats, one NaN.
+    assert xdata[0] == 1.5
+    assert xdata[2] == 3.5
+    # NaN is the substitute for non-coercible values.
+    import math
+
+    assert math.isnan(xdata[1])
+
+
+def test_serialize_bar_container_ignores_non_rectangle_patches(monkeypatch):
+    """BarContainer with stray non-Rectangle patches must skip them."""
+    fig, ax = plt.subplots()
+    bars = ax.bar([1, 2], [3, 4])
+
+    # Inject a non-Rectangle into the bar container's patches list.
+    bars.patches = list(bars.patches) + [matplotlib.patches.Circle((0, 0), 0.1)]
+
+    data = serialize_figure(fig)
+    # Only the two Rectangle bars are reported; the Circle was skipped.
+    assert len(data["axes"][0]["bars"]) == 2
+
+
+def test_serialize_handles_masked_array_data():
+    """matplotlib commonly stores xdata/ydata as numpy MaskedArrays."""
+    fig, ax = plt.subplots()
+    # Calling ax.plot with a masked array is uncommon; the realistic
+    # path is that get_xdata returns a regular ndarray. We still
+    # exercise the masked path here to confirm the converter survives.
+    mx = np.ma.array([1.0, 2.0, 3.0], mask=[False, True, False])
+    my = np.ma.array([4.0, 5.0, 6.0], mask=[False, False, False])
+    ax.plot(mx, my)
+    data = serialize_figure(fig)
+    line = data["axes"][0]["lines"][0]
+    assert len(line["xdata"]) == 3
+    assert len(line["ydata"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration with the worker
+# ---------------------------------------------------------------------------
+
+
+def test_worker_emits_figure_events(tmp_path):
+    """The Python worker should serialize any open figures on success."""
+    import textwrap
+
+    from generic_grader.sandbox.protocol import Request
+    from generic_grader.sandbox.python_runtime import run_request
+
+    (tmp_path / "submission.py").write_text(
+        textwrap.dedent(
+            """
+            import matplotlib
+            matplotlib.use("Agg")
+            import matplotlib.pyplot as plt
+            def main():
+                fig, ax = plt.subplots()
+                ax.plot([1, 2, 3], [4, 5, 6])
+                ax.set_title("hello")
+            """
+        )
+    )
+    resp = run_request(
+        Request(
+            runtime="python",
+            submission_dir=str(tmp_path),
+            module="submission",
+            obj_name="main",
+        )
+    )
+    figs = [e for e in resp.events if e.type == "figure"]
+    assert len(figs) == 1
+    assert figs[0].properties["axes"][0]["title"] == "hello"
+
+
+def test_worker_skips_figures_when_not_in_captures(tmp_path):
+    """Tests that don't need figures can opt out via captures."""
+    import textwrap
+
+    from generic_grader.sandbox.protocol import Request
+    from generic_grader.sandbox.python_runtime import run_request
+
+    (tmp_path / "submission.py").write_text(
+        textwrap.dedent(
+            """
+            import matplotlib
+            matplotlib.use("Agg")
+            import matplotlib.pyplot as plt
+            def main():
+                fig, ax = plt.subplots()
+                ax.plot([1], [1])
+            """
+        )
+    )
+    resp = run_request(
+        Request(
+            runtime="python",
+            submission_dir=str(tmp_path),
+            module="submission",
+            obj_name="main",
+            captures=("return", "exception"),
+        )
+    )
+    figs = [e for e in resp.events if e.type == "figure"]
+    assert figs == []
+
+
+def test_worker_closes_figures_after_capture(tmp_path):
+    """After a run, no figures should leak into the host's pyplot state.
+
+    This matters because the worker process is normally short-lived
+    (the isolate runner spawns a fresh one per test), but we exercise
+    the in-process path in unit tests and a leaked figure would cause
+    surprising interactions between tests.
+    """
+    import textwrap
+
+    from generic_grader.sandbox.protocol import Request
+    from generic_grader.sandbox.python_runtime import run_request
+
+    (tmp_path / "submission.py").write_text(
+        textwrap.dedent(
+            """
+            import matplotlib
+            matplotlib.use("Agg")
+            import matplotlib.pyplot as plt
+            def main():
+                plt.figure()
+                plt.plot([1, 2], [3, 4])
+            """
+        )
+    )
+    plt.close("all")
+    run_request(
+        Request(
+            runtime="python",
+            submission_dir=str(tmp_path),
+            module="submission",
+            obj_name="main",
+        )
+    )
+    assert plt.get_fignums() == []

--- a/tests/sandbox/test_integration.py
+++ b/tests/sandbox/test_integration.py
@@ -25,6 +25,7 @@ from generic_grader.sandbox.integration import (
     default_runner_factory,
     get_default_box_pool,
     iter_events,
+    pool_for_xdist_worker,
     sandbox_call_obj,
     sandbox_import_obj,
 )
@@ -86,6 +87,44 @@ def test_get_default_box_pool_returns_singleton():
     b = get_default_box_pool()
     assert a is b
     assert isinstance(a, BoxPool)
+
+
+def test_pool_for_xdist_worker_master_uses_base_zero():
+    pool = pool_for_xdist_worker("master", size=4)
+    ids = sorted(pool.acquire() for _ in range(4))
+    assert ids == [0, 1, 2, 3]
+
+
+def test_pool_for_xdist_worker_gw_offsets_by_index():
+    """Each gw<N> worker gets a disjoint, contiguous range of box ids."""
+    pool_gw0 = pool_for_xdist_worker("gw0", size=4)
+    pool_gw1 = pool_for_xdist_worker("gw1", size=4)
+    pool_gw2 = pool_for_xdist_worker("gw2", size=4)
+    assert sorted(pool_gw0.acquire() for _ in range(4)) == [0, 1, 2, 3]
+    assert sorted(pool_gw1.acquire() for _ in range(4)) == [4, 5, 6, 7]
+    assert sorted(pool_gw2.acquire() for _ in range(4)) == [8, 9, 10, 11]
+
+
+def test_pool_for_xdist_worker_uses_default_size():
+    pool = pool_for_xdist_worker("gw0")
+    # Just verify it succeeds and produces a pool sized to the default.
+    ids = [pool.acquire() for _ in range(DEFAULT_BOX_POOL_SIZE)]
+    assert len(set(ids)) == DEFAULT_BOX_POOL_SIZE
+
+
+def test_pool_for_xdist_worker_rejects_malformed_id():
+    with pytest.raises(ValueError, match="unrecognized xdist worker_id"):
+        pool_for_xdist_worker("gwX")
+
+
+def test_pool_for_xdist_worker_unknown_prefix_falls_back_to_base_zero():
+    """Anything that isn't 'master' or 'gw<N>' is treated like master.
+
+    This guards against future xdist naming changes from silently
+    bricking the pool -- the worker just shares the master range.
+    """
+    pool = pool_for_xdist_worker("weird-id", size=2)
+    assert sorted(pool.acquire() for _ in range(2)) == [0, 1]
 
 
 def test_default_box_pool_size_constant():

--- a/tests/sandbox/test_integration.py
+++ b/tests/sandbox/test_integration.py
@@ -1,0 +1,565 @@
+"""Tests for the sandbox integration module.
+
+The integration module is the host-side bridge between the existing
+`Importer` / `User` API and the sandboxed worker.  Tests inject a
+fake runner so they don't require a real isolate install.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, List
+
+import pytest
+
+from generic_grader.sandbox.integration import (
+    DEFAULT_BOX_POOL_SIZE,
+    BoxPool,
+    SandboxRunResult,
+    _replay_events,
+    _resolve_exception_class,
+    _resolve_submission_dir,
+    classify_call_outcome,
+    classify_import_outcome,
+    default_runner_factory,
+    get_default_box_pool,
+    iter_events,
+    sandbox_call_obj,
+    sandbox_import_obj,
+)
+from generic_grader.sandbox.protocol import Event, PatchSpec, Request, Response
+from generic_grader.sandbox.runner import IsolateRunner
+from generic_grader.utils.exceptions import EndOfInputError, ExtraEntriesError
+from generic_grader.utils.options import Options
+
+# ---------------------------------------------------------------------------
+# BoxPool
+# ---------------------------------------------------------------------------
+
+
+def test_box_pool_acquires_and_releases_distinct_ids():
+    pool = BoxPool(size=3, base=10)
+    a = pool.acquire()
+    b = pool.acquire()
+    c = pool.acquire()
+    assert {a, b, c} == {10, 11, 12}
+    pool.release(b)
+    assert pool.acquire() == 11
+
+
+def test_box_pool_rejects_invalid_size():
+    with pytest.raises(ValueError, match="size must be >= 1"):
+        BoxPool(size=0)
+
+
+def test_box_pool_rejects_invalid_base():
+    with pytest.raises(ValueError, match="base must be >= 0"):
+        BoxPool(size=4, base=-1)
+
+
+def test_box_pool_blocks_until_release():
+    """An empty pool blocks acquire; release wakes a waiter."""
+    pool = BoxPool(size=1, base=5)
+    first = pool.acquire()
+    assert first == 5
+
+    woke = threading.Event()
+    second_holder: dict[str, int] = {}
+
+    def waiter():
+        second_holder["id"] = pool.acquire()
+        woke.set()
+
+    t = threading.Thread(target=waiter)
+    t.start()
+    # Give the waiter time to block.
+    assert not woke.wait(0.05)
+    pool.release(first)
+    assert woke.wait(1.0), "release did not wake waiter"
+    t.join(timeout=1.0)
+    assert second_holder["id"] == 5
+
+
+def test_get_default_box_pool_returns_singleton():
+    a = get_default_box_pool()
+    b = get_default_box_pool()
+    assert a is b
+    assert isinstance(a, BoxPool)
+
+
+def test_default_box_pool_size_constant():
+    """The default size is sensible and matches the constant."""
+    assert DEFAULT_BOX_POOL_SIZE >= 1
+
+
+# ---------------------------------------------------------------------------
+# Event replay
+# ---------------------------------------------------------------------------
+
+
+def _resp(events: list[Event], **kwargs: Any) -> Response:
+    return Response(events=events, **kwargs)
+
+
+def test_replay_events_collects_stdout_into_log():
+    resp = _resp([Event("stdout", data="hello "), Event("stdout", data="world")])
+    result = _replay_events(resp)
+    assert result.log == "hello world"
+    assert result.interactions == [0]
+
+
+def test_replay_events_records_interactions_on_stdin():
+    """Each stdin event marks the log position before its line."""
+    resp = _resp(
+        [
+            Event("stdout", data="prompt> "),
+            Event("stdin", data="42"),
+            Event("stdout", data="thanks\n"),
+            Event("stdout", data="next> "),
+            Event("stdin", data="7"),
+        ]
+    )
+    result = _replay_events(resp)
+    # Log: "prompt> 42\nthanks\nnext> 7\n"
+    # interactions[0] = 0 (start), interactions[1] = len("prompt> ")=8,
+    # interactions[2] = len("prompt> 42\nthanks\nnext> ") = 24
+    assert result.log == "prompt> 42\nthanks\nnext> 7\n"
+    assert result.interactions == [0, 8, 24]
+
+
+def test_replay_events_drops_stderr_from_log():
+    """Stderr writes don't show up in the IO log (parity with legacy)."""
+    resp = _resp(
+        [
+            Event("stdout", data="ok"),
+            Event("stderr", data="warn"),
+            Event("stdin", data="x"),
+        ]
+    )
+    result = _replay_events(resp)
+    assert result.log == "okx\n"
+
+
+def test_replay_events_captures_return_value():
+    resp = _resp([Event("return", value={"answer": 42})])
+    result = _replay_events(resp)
+    assert result.return_value == {"answer": 42}
+    assert result.return_non_serializable is False
+
+
+def test_replay_events_captures_non_serializable_return():
+    resp = _resp([Event("return", non_serializable=True, repr="<MyObj>")])
+    result = _replay_events(resp)
+    assert result.return_non_serializable is True
+    assert result.return_repr == "<MyObj>"
+    assert result.return_value is None
+
+
+def test_replay_events_collects_figures():
+    resp = _resp(
+        [
+            Event("figure", properties={"title": "Plot 1"}),
+            Event("figure", properties={"title": "Plot 2"}),
+        ]
+    )
+    result = _replay_events(resp)
+    assert result.figures == [{"title": "Plot 1"}, {"title": "Plot 2"}]
+
+
+def test_replay_events_counts_unused_entries():
+    resp = _resp([Event("unused_entries", count=3)])
+    result = _replay_events(resp)
+    assert result.unused_entries == 3
+
+
+def test_replay_events_flags_input_during_import():
+    """A stdin event observed during the import phase is flagged."""
+    resp = _resp(
+        [
+            # No phase event before the first stdin -> still considered import.
+            Event("stdin", data="bad"),
+            Event("phase", name="call"),
+            Event("stdin", data="ok"),
+        ]
+    )
+    result = _replay_events(resp)
+    assert result.consumed_input_during_import is True
+
+
+def test_replay_events_does_not_flag_input_after_call_phase():
+    resp = _resp(
+        [
+            Event("phase", name="call"),
+            Event("stdin", data="ok"),
+        ]
+    )
+    result = _replay_events(resp)
+    assert result.consumed_input_during_import is False
+
+
+def test_replay_events_preserves_exception_and_elapsed():
+    resp = _resp([], exception=[{"type": "ValueError"}], elapsed_seconds=0.42)
+    result = _replay_events(resp)
+    assert result.exception == [{"type": "ValueError"}]
+    assert result.elapsed_seconds == 0.42
+    assert result.response is resp
+
+
+# ---------------------------------------------------------------------------
+# submission_dir resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_submission_dir_returns_cwd_for_plain_module(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    opts = Options(sub_module="submission")
+    assert _resolve_submission_dir(opts, "submission") == str(tmp_path)
+
+
+def test_resolve_submission_dir_handles_dotted_module(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tests").mkdir()
+    opts = Options()
+    assert _resolve_submission_dir(opts, "tests.reference") == str(tmp_path)
+
+
+def test_resolve_submission_dir_falls_back_when_package_missing(tmp_path, monkeypatch):
+    """Missing dotted package: still return cwd; the worker raises."""
+    monkeypatch.chdir(tmp_path)
+    opts = Options()
+    assert _resolve_submission_dir(opts, "nonexistent.pkg") == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Fake runner harness
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeRunner:
+    response: Response
+    box_id: int = 0
+    received: List[Request] = None
+
+    def __post_init__(self):
+        if self.received is None:
+            self.received = []
+
+    def run(self, request: Request) -> Response:
+        self.received.append(request)
+        return self.response
+
+
+def _make_factory(response: Response) -> Callable[[int], _FakeRunner]:
+    holder: dict[str, _FakeRunner] = {}
+
+    def factory(box_id: int) -> _FakeRunner:
+        runner = _FakeRunner(response=response, box_id=box_id)
+        holder["last"] = runner
+        return runner
+
+    factory.holder = holder  # type: ignore[attr-defined]
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# sandbox_import_obj
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_import_obj_uses_fresh_box(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    pool = BoxPool(size=2, base=20)
+    response = _resp([], exception=None)
+    factory = _make_factory(response)
+    opts = Options()
+    result = sandbox_import_obj(
+        "submission",
+        opts,
+        runner_factory=factory,
+        box_pool=pool,
+    )
+    assert result.exception is None
+    # box pool fully replenished after the call returns.
+    assert sorted([pool.acquire(), pool.acquire()]) == [20, 21]
+
+
+def test_sandbox_import_obj_sends_noop_patch_for_target(tmp_path, monkeypatch):
+    """The import probe wraps the target in a noop spec so the call is harmless."""
+    monkeypatch.chdir(tmp_path)
+    response = _resp([])
+    factory = _make_factory(response)
+    opts = Options(obj_name="main", sub_module="submission")
+    sandbox_import_obj(
+        "submission", opts, runner_factory=factory, box_pool=BoxPool(size=1)
+    )
+    sent: Request = factory.holder["last"].received[0]
+    targets = [spec.target for spec in sent.patch_specs]
+    assert "submission.main" in targets
+    # Must be a noop, never any other kind.
+    noop_specs = [s for s in sent.patch_specs if s.target == "submission.main"]
+    assert all(s.kind == "noop" for s in noop_specs)
+
+
+def test_sandbox_import_obj_releases_box_on_runner_failure(tmp_path, monkeypatch):
+    """If the runner raises, the box id must still be returned."""
+    monkeypatch.chdir(tmp_path)
+    pool = BoxPool(size=1, base=42)
+
+    class _BoomRunner:
+        def __init__(self, box_id):
+            self.box_id = box_id
+
+        def run(self, request):
+            raise RuntimeError("kaboom")
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        sandbox_import_obj(
+            "submission",
+            Options(),
+            runner_factory=_BoomRunner,
+            box_pool=pool,
+        )
+    # Pool is restored.
+    assert pool.acquire() == 42
+
+
+def test_sandbox_import_obj_uses_empty_entries(tmp_path, monkeypatch):
+    """Even if Options.entries is set, the import probe sends empty entries."""
+    monkeypatch.chdir(tmp_path)
+    response = _resp([])
+    factory = _make_factory(response)
+    opts = Options(entries=("a", "b"))
+    sandbox_import_obj(
+        "submission", opts, runner_factory=factory, box_pool=BoxPool(size=1)
+    )
+    sent: Request = factory.holder["last"].received[0]
+    assert sent.entries == ()
+
+
+def test_sandbox_import_obj_carries_user_patch_specs(tmp_path, monkeypatch):
+    """Custom user patch_specs are forwarded after the import-only spec."""
+    monkeypatch.chdir(tmp_path)
+    response = _resp([])
+    factory = _make_factory(response)
+    user_spec = PatchSpec(target="builtins.print", kind="noop")
+    opts = Options(patch_specs=(user_spec,))
+    sandbox_import_obj(
+        "submission", opts, runner_factory=factory, box_pool=BoxPool(size=1)
+    )
+    sent: Request = factory.holder["last"].received[0]
+    targets = [s.target for s in sent.patch_specs]
+    # Both specs present; import-only spec ordered first so it can't be
+    # overridden by a user spec on the same target.
+    assert targets[0] == "submission.main"
+    assert "builtins.print" in targets
+
+
+# ---------------------------------------------------------------------------
+# sandbox_call_obj
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_call_obj_forwards_args_kwargs_entries(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    response = _resp([Event("return", value=99)])
+    factory = _make_factory(response)
+    opts = Options(args=(1, 2), kwargs={"k": "v"}, entries=("x",))
+    result = sandbox_call_obj(
+        "submission", opts, runner_factory=factory, box_pool=BoxPool(size=1)
+    )
+    sent: Request = factory.holder["last"].received[0]
+    assert sent.args == (1, 2)
+    assert sent.kwargs == {"k": "v"}
+    assert sent.entries == ("x",)
+    assert result.return_value == 99
+
+
+def test_sandbox_call_obj_uses_entries_override(tmp_path, monkeypatch):
+    """Explicit ``entries`` overrides Options.entries."""
+    monkeypatch.chdir(tmp_path)
+    response = _resp([])
+    factory = _make_factory(response)
+    opts = Options(entries=("ignored",))
+    sandbox_call_obj(
+        "submission",
+        opts,
+        runner_factory=factory,
+        box_pool=BoxPool(size=1),
+        entries=("override",),
+    )
+    sent: Request = factory.holder["last"].received[0]
+    assert sent.entries == ("override",)
+
+
+def test_sandbox_call_obj_propagates_patch_specs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    response = _resp([])
+    factory = _make_factory(response)
+    spec = PatchSpec(target="builtins.exit", kind="noop")
+    opts = Options(patch_specs=(spec,))
+    sandbox_call_obj(
+        "submission", opts, runner_factory=factory, box_pool=BoxPool(size=1)
+    )
+    sent: Request = factory.holder["last"].received[0]
+    assert sent.patch_specs == (spec,)
+
+
+def test_sandbox_call_obj_uses_fresh_box(tmp_path, monkeypatch):
+    """Two back-to-back call_obj invocations both use distinct boxes."""
+    monkeypatch.chdir(tmp_path)
+    pool = BoxPool(size=2, base=30)
+    response = _resp([])
+    boxes_seen: list[int] = []
+
+    def factory(box_id: int) -> _FakeRunner:
+        boxes_seen.append(box_id)
+        return _FakeRunner(response=response, box_id=box_id)
+
+    opts = Options()
+    sandbox_call_obj("submission", opts, runner_factory=factory, box_pool=pool)
+    sandbox_call_obj("submission", opts, runner_factory=factory, box_pool=pool)
+    # Each call grabs a box and releases it; the pool reuses the same one.
+    assert len(boxes_seen) == 2
+
+
+def test_sandbox_call_obj_propagates_fixed_time(tmp_path, monkeypatch):
+    import datetime as _dt
+
+    monkeypatch.chdir(tmp_path)
+    response = _resp([])
+    factory = _make_factory(response)
+    opts = Options(fixed_time="2024-01-01")
+    sandbox_call_obj(
+        "submission", opts, runner_factory=factory, box_pool=BoxPool(size=1)
+    )
+    sent: Request = factory.holder["last"].received[0]
+    assert sent.fixed_time == "2024-01-01"
+
+    # Datetime is converted to ISO 8601.
+    factory2 = _make_factory(response)
+    opts2 = Options(fixed_time=_dt.datetime(2030, 6, 1, 12, 0, 0))
+    sandbox_call_obj(
+        "submission", opts2, runner_factory=factory2, box_pool=BoxPool(size=1)
+    )
+    sent2: Request = factory2.holder["last"].received[0]
+    assert sent2.fixed_time and sent2.fixed_time.startswith("2030-06-01")
+
+
+def test_sandbox_call_obj_passes_no_fixed_time_for_false(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    response = _resp([])
+    factory = _make_factory(response)
+    opts = Options(fixed_time=False)
+    sandbox_call_obj(
+        "submission", opts, runner_factory=factory, box_pool=BoxPool(size=1)
+    )
+    sent: Request = factory.holder["last"].received[0]
+    assert sent.fixed_time is None
+
+
+def test_sandbox_call_obj_propagates_limits(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    response = _resp([])
+    factory = _make_factory(response)
+    opts = Options(time_limit=3, memory_limit_GB=0.5, log_limit=1024)
+    sandbox_call_obj(
+        "submission", opts, runner_factory=factory, box_pool=BoxPool(size=1)
+    )
+    sent: Request = factory.holder["last"].received[0]
+    assert sent.time_limit_seconds == 3.0
+    assert sent.memory_limit_mb == 512
+    assert sent.log_limit == 1024
+
+
+# ---------------------------------------------------------------------------
+# Outcome classification
+# ---------------------------------------------------------------------------
+
+
+def test_classify_import_outcome_success_returns_none():
+    result = SandboxRunResult(exception=None)
+    assert classify_import_outcome(result) is None
+
+
+def test_classify_import_outcome_detects_stuck_at_input():
+    result = SandboxRunResult(consumed_input_during_import=True)
+    assert classify_import_outcome(result) is EndOfInputError
+
+
+def test_classify_import_outcome_maps_eof_error_to_end_of_input():
+    result = SandboxRunResult(exception=[{"type": "EOFError", "message": ""}])
+    assert classify_import_outcome(result) is EndOfInputError
+
+
+def test_classify_import_outcome_resolves_other_exceptions():
+    result = SandboxRunResult(exception=[{"type": "ModuleNotFoundError"}])
+    assert classify_import_outcome(result) is ModuleNotFoundError
+
+
+def test_classify_call_outcome_extra_entries_when_leftover():
+    result = SandboxRunResult(exception=None, unused_entries=2)
+    assert classify_call_outcome(result) is ExtraEntriesError
+
+
+def test_classify_call_outcome_no_leftover_no_exception():
+    result = SandboxRunResult(exception=None, unused_entries=0)
+    assert classify_call_outcome(result) is None
+
+
+def test_classify_call_outcome_resolves_exception_type():
+    result = SandboxRunResult(exception=[{"type": "ValueError"}])
+    assert classify_call_outcome(result) is ValueError
+
+
+def test_classify_call_outcome_falls_back_to_exception():
+    result = SandboxRunResult(exception=[{"type": "DefinitelyNotAClass"}])
+    assert classify_call_outcome(result) is Exception
+
+
+# ---------------------------------------------------------------------------
+# Exception class resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_exception_class_builtins():
+    assert _resolve_exception_class("ValueError") is ValueError
+    assert _resolve_exception_class("ZeroDivisionError") is ZeroDivisionError
+
+
+def test_resolve_exception_class_grader_exceptions():
+    from generic_grader.utils.exceptions import ExitError
+
+    assert _resolve_exception_class("ExitError") is ExitError
+
+
+def test_resolve_exception_class_unknown_returns_exception():
+    assert _resolve_exception_class("ThisIsNotAClassName") is Exception
+
+
+def test_resolve_exception_class_handles_non_exception_attr():
+    """If the resolved attribute exists but isn't an exception, fall back."""
+    # `int` is a builtin but isn't a BaseException subclass.
+    assert _resolve_exception_class("int") is Exception
+
+
+# ---------------------------------------------------------------------------
+# Misc helpers
+# ---------------------------------------------------------------------------
+
+
+def test_iter_events_yields_dicts():
+    resp = _resp([Event("stdout", data="hi"), Event("return", value=1)])
+    events = list(iter_events(resp))
+    assert events == [
+        {"type": "stdout", "data": "hi"},
+        {"type": "return", "value": 1},
+    ]
+
+
+def test_default_runner_factory_builds_isolate_runner():
+    runner = default_runner_factory(7)
+    assert isinstance(runner, IsolateRunner)
+    assert runner.box_id == 7
+    assert "generic_grader" not in runner.grader_src.split("/")[-1:]

--- a/tests/sandbox/test_octave_runtime.py
+++ b/tests/sandbox/test_octave_runtime.py
@@ -1,0 +1,77 @@
+"""Tests for the Octave runtime stub.
+
+The stub returns a structured error response so the host can surface
+"Octave isn't built yet" without crashing the worker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from generic_grader.sandbox.octave_runtime import run_request
+from generic_grader.sandbox.protocol import Request
+
+
+def _make_request() -> Request:
+    return Request(
+        runtime="octave",
+        submission_dir="/tmp",
+        module="m",
+        obj_name="f",
+    )
+
+
+def test_octave_run_request_returns_response():
+    response = run_request(_make_request())
+    assert response.events == []
+    assert response.exception is not None
+    assert len(response.exception) == 1
+
+
+def test_octave_run_request_exception_type_is_runtime_not_implemented():
+    response = run_request(_make_request())
+    assert response.exception[0]["type"] == "RuntimeNotImplementedError"
+
+
+def test_octave_run_request_message_mentions_issue_and_alternative():
+    response = run_request(_make_request())
+    msg = response.exception[0]["message"]
+    assert "Octave" in msg
+    assert "not implemented" in msg
+    assert "python" in msg
+
+
+def test_octave_run_request_traceback_is_empty():
+    response = run_request(_make_request())
+    assert response.exception[0]["traceback"] == ""
+
+
+def test_octave_run_request_elapsed_time_is_zero():
+    """A stub returns instantly; the timer reflects that."""
+    response = run_request(_make_request())
+    assert response.elapsed_seconds == 0.0
+
+
+def test_octave_run_request_roundtrips_through_protocol_json():
+    """Stub response is JSON-serializable like every other response."""
+    import json
+
+    response = run_request(_make_request())
+    payload = json.loads(response.to_json())
+    assert payload["exception"][0]["type"] == "RuntimeNotImplementedError"
+
+
+@pytest.mark.parametrize(
+    "obj_name",
+    ["main", "process_data", "with_underscores"],
+)
+def test_octave_run_request_ignores_request_fields(obj_name):
+    """The stub returns the same error regardless of request contents."""
+    request = Request(
+        runtime="octave",
+        submission_dir="/anywhere",
+        module="ignored",
+        obj_name=obj_name,
+    )
+    response = run_request(request)
+    assert response.exception[0]["type"] == "RuntimeNotImplementedError"

--- a/tests/sandbox/test_patch_specs.py
+++ b/tests/sandbox/test_patch_specs.py
@@ -1,0 +1,133 @@
+"""Tests for the host-side `PatchSpec` builders."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from generic_grader.sandbox.patch_specs import (
+    make_iter_patch_spec,
+    make_noop_patch_spec,
+    make_raise_error_patch_spec,
+    make_source_patch_spec,
+)
+from generic_grader.sandbox.protocol import PatchSpec
+
+# ---------------------------------------------------------------------------
+# noop
+# ---------------------------------------------------------------------------
+
+
+def test_noop_basic():
+    spec = make_noop_patch_spec("matplotlib.pyplot.show")
+    assert spec == PatchSpec(target="matplotlib.pyplot.show", kind="noop")
+
+
+def test_noop_passes_through_patch_kwargs():
+    spec = make_noop_patch_spec("turtle.write", patch_kwargs={"create": True})
+    assert spec.patch_kwargs == {"create": True}
+
+
+# ---------------------------------------------------------------------------
+# iter_returns
+# ---------------------------------------------------------------------------
+
+
+def test_iter_returns_records_values_in_order():
+    spec = make_iter_patch_spec("random.random", [0.5, 0.25, 0.125])
+    assert spec.kind == "iter_returns"
+    assert spec.values == [0.5, 0.25, 0.125]
+
+
+def test_iter_returns_copies_values_so_caller_mutation_is_isolated():
+    values = [1, 2, 3]
+    spec = make_iter_patch_spec("m.f", values)
+    values.append(4)
+    assert spec.values == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# raise_error
+# ---------------------------------------------------------------------------
+
+
+def test_raise_error_uses_qualified_class_name():
+    from generic_grader.utils.exceptions import TurtleDoneError
+
+    spec = make_raise_error_patch_spec("turtle.done", TurtleDoneError)
+    assert spec.kind == "raise_error"
+    assert spec.error_qualname == ("generic_grader.utils.exceptions.TurtleDoneError")
+
+
+def test_raise_error_rejects_non_exception_classes():
+    with pytest.raises(TypeError, match="exception class"):
+        make_raise_error_patch_spec("x", "not a class")  # type: ignore[arg-type]
+
+
+def test_raise_error_rejects_non_exception_subclass():
+    with pytest.raises(TypeError, match="exception class"):
+        make_raise_error_patch_spec("x", int)
+
+
+# ---------------------------------------------------------------------------
+# source
+# ---------------------------------------------------------------------------
+
+
+def _module_level_fake(time):  # pragma: no cover - source-captured
+    return (time * 1234567.89) % 125
+
+
+def test_source_captures_module_level_function():
+    spec = make_source_patch_spec("falling.falling_dist", _module_level_fake)
+    assert spec.kind == "source"
+    assert spec.name == "_module_level_fake"
+    assert "1234567.89" in spec.source
+
+
+def test_source_rejects_lambda():
+    with pytest.raises(ValueError, match="lambda"):
+        make_source_patch_spec("x", lambda v: v)
+
+
+def test_source_rejects_non_callable():
+    with pytest.raises(TypeError, match="callable"):
+        make_source_patch_spec("x", 42)  # type: ignore[arg-type]
+
+
+def test_source_dedents_function_defined_in_nested_scope():
+    # Functions defined inside a test get indented; inspect.getsource
+    # returns the original indentation, so the helper must dedent.
+    def _nested(time):  # pragma: no cover - source-captured
+        return time + 1
+
+    spec = make_source_patch_spec("m.f", _nested)
+    # First non-blank line must be flush-left after dedent.
+    first_line = next(line for line in spec.source.splitlines() if line.strip())
+    assert first_line.startswith("def ")
+
+
+def test_source_raises_when_source_unavailable():
+    # Builtins are callables whose source cannot be retrieved.
+    with pytest.raises(ValueError, match="Cannot capture source"):
+        make_source_patch_spec("x", len)
+
+
+# ---------------------------------------------------------------------------
+# JSON portability
+# ---------------------------------------------------------------------------
+
+
+def test_all_specs_are_json_serializable():
+    from generic_grader.utils.exceptions import TurtleDoneError
+
+    specs = [
+        make_noop_patch_spec("a"),
+        make_iter_patch_spec("b", [1, 2]),
+        make_raise_error_patch_spec("c", TurtleDoneError),
+        make_source_patch_spec("d", _module_level_fake),
+    ]
+    payload = json.dumps([s.to_dict() for s in specs])
+    decoded = [PatchSpec.from_dict(d) for d in json.loads(payload)]
+    assert decoded == specs

--- a/tests/sandbox/test_protocol.py
+++ b/tests/sandbox/test_protocol.py
@@ -155,7 +155,7 @@ def test_request_minimal_fields():
     """A Request needs at least runtime + submission_dir + module + obj_name."""
     r = Request(
         runtime="python",
-        submission_dir="/box/submission",
+        submission_dir="/submission",
         module="submission",
         obj_name="main",
     )
@@ -169,7 +169,7 @@ def test_request_minimal_fields():
 def test_request_to_json_round_trip():
     r = Request(
         runtime="python",
-        submission_dir="/box/submission",
+        submission_dir="/submission",
         module="submission",
         obj_name="compute_area",
         args=(3, 4),
@@ -187,7 +187,7 @@ def test_request_to_json_round_trip():
 def test_request_to_json_is_valid_json():
     r = Request(
         runtime="python",
-        submission_dir="/box/submission",
+        submission_dir="/submission",
         module="submission",
         obj_name="main",
     )
@@ -202,7 +202,7 @@ def test_request_from_json_rejects_wrong_protocol_version():
         {
             "protocol_version": PROTOCOL_VERSION + 99,
             "runtime": "python",
-            "submission_dir": "/box/submission",
+            "submission_dir": "/submission",
             "module": "submission",
             "obj_name": "main",
         }
@@ -222,7 +222,7 @@ def test_request_write_read_round_trip():
     """`write_request` -> `read_request` should be lossless across a stream."""
     r = Request(
         runtime="python",
-        submission_dir="/box/submission",
+        submission_dir="/submission",
         module="m",
         obj_name="f",
         args=(1, 2),
@@ -454,7 +454,7 @@ def test_request_round_trips_patch_specs():
     )
     req = Request(
         runtime="python",
-        submission_dir="/box/submission",
+        submission_dir="/submission",
         module="submission",
         obj_name="main",
         patch_specs=specs,
@@ -466,7 +466,7 @@ def test_request_round_trips_patch_specs():
 def test_request_patch_specs_defaults_to_empty_tuple():
     req = Request(
         runtime="python",
-        submission_dir="/box/submission",
+        submission_dir="/submission",
         module="submission",
         obj_name="main",
     )

--- a/tests/sandbox/test_protocol.py
+++ b/tests/sandbox/test_protocol.py
@@ -1,0 +1,371 @@
+"""Tests for the sandbox IPC protocol (request/response shape and framing).
+
+The protocol is intentionally runtime-agnostic: the same envelope can carry
+a Python or Octave request, distinguished by the `runtime` field. Framing
+uses a decimal byte length followed by a newline, then the JSON payload,
+so newlines inside captured output do not corrupt frame boundaries.
+"""
+
+import io
+import json
+
+import pytest
+
+from generic_grader.sandbox.protocol import (
+    PROTOCOL_VERSION,
+    Event,
+    Request,
+    Response,
+    SandboxException,
+    read_frame,
+    read_request,
+    read_response,
+    write_frame,
+    write_request,
+    write_response,
+)
+
+# ---------------------------------------------------------------------------
+# Framing
+# ---------------------------------------------------------------------------
+
+
+def test_write_frame_round_trip_simple():
+    buf = io.BytesIO()
+    write_frame(buf, b'{"hello": "world"}')
+    buf.seek(0)
+    assert read_frame(buf) == b'{"hello": "world"}'
+
+
+def test_write_frame_round_trip_with_newlines():
+    """Payloads containing newlines must survive framing intact."""
+    payload = b'{"events":[{"type":"stdout","data":"line one\\nline two\\n"}]}'
+    buf = io.BytesIO()
+    write_frame(buf, payload)
+    buf.seek(0)
+    assert read_frame(buf) == payload
+
+
+def test_write_frame_round_trip_multiple_frames():
+    buf = io.BytesIO()
+    write_frame(buf, b"first")
+    write_frame(buf, b"second\nwith\nnewlines")
+    write_frame(buf, b"third")
+    buf.seek(0)
+    assert read_frame(buf) == b"first"
+    assert read_frame(buf) == b"second\nwith\nnewlines"
+    assert read_frame(buf) == b"third"
+
+
+def test_read_frame_eof_returns_none():
+    """An empty stream should signal EOF as None, not raise."""
+    buf = io.BytesIO(b"")
+    assert read_frame(buf) is None
+
+
+def test_read_frame_rejects_non_decimal_length():
+    buf = io.BytesIO(b"abc\n{}")
+    with pytest.raises(SandboxException) as exc_info:
+        read_frame(buf)
+    assert "length" in str(exc_info.value).lower()
+
+
+def test_read_frame_rejects_truncated_payload():
+    """If the declared length exceeds what's available, that's a protocol error."""
+    buf = io.BytesIO(b"100\n{}")
+    with pytest.raises(SandboxException) as exc_info:
+        read_frame(buf)
+    assert "truncated" in str(exc_info.value).lower()
+
+
+def test_read_frame_rejects_negative_length():
+    buf = io.BytesIO(b"-5\nhello")
+    with pytest.raises(SandboxException):
+        read_frame(buf)
+
+
+def test_read_frame_handles_empty_payload():
+    """A zero-length frame is valid and yields an empty bytes object."""
+    buf = io.BytesIO()
+    write_frame(buf, b"")
+    buf.seek(0)
+    assert read_frame(buf) == b""
+
+
+def test_write_frame_rejects_non_bytes_payload():
+    """`write_frame` must refuse text-mode payloads to keep the wire stable."""
+    with pytest.raises(TypeError):
+        write_frame(io.BytesIO(), "not bytes")  # type: ignore[arg-type]
+
+
+def test_write_frame_calls_flush_when_available():
+    """Writers backed by a pipe rely on `flush` being invoked."""
+
+    class _FlushTracker(io.BytesIO):
+        flushed = False
+
+        def flush(self):  # type: ignore[override]
+            type(self).flushed = True
+            super().flush()
+
+    sink = _FlushTracker()
+    write_frame(sink, b"ok")
+    assert _FlushTracker.flushed is True
+
+
+def test_write_frame_tolerates_stream_without_flush():
+    """Some readers/writers (test fakes) omit `flush`; that must be OK."""
+
+    class _NoFlush:
+        def __init__(self):
+            self.chunks = []
+
+        def write(self, data):
+            self.chunks.append(bytes(data))
+            return len(data)
+
+    sink = _NoFlush()
+    write_frame(sink, b"hi")
+    assert b"".join(sink.chunks) == b"2\nhi"
+
+
+def test_read_frame_rejects_eof_mid_header():
+    """A few digits followed by EOF (no terminator) is a protocol error."""
+    buf = io.BytesIO(b"42")
+    with pytest.raises(SandboxException) as exc_info:
+        read_frame(buf)
+    assert "truncated" in str(exc_info.value).lower()
+
+
+def test_read_frame_rejects_overlong_header():
+    """A length header longer than 20 digits cannot be a valid byte count."""
+    buf = io.BytesIO(b"1" * 30 + b"\n")
+    with pytest.raises(SandboxException) as exc_info:
+        read_frame(buf)
+    assert "length" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Request envelope
+# ---------------------------------------------------------------------------
+
+
+def test_request_minimal_fields():
+    """A Request needs at least runtime + submission_dir + module + obj_name."""
+    r = Request(
+        runtime="python",
+        submission_dir="/box/submission",
+        module="submission",
+        obj_name="main",
+    )
+    assert r.protocol_version == PROTOCOL_VERSION
+    assert r.args == ()
+    assert r.kwargs == {}
+    assert r.entries == ()
+    assert r.captures == ("stdout", "stderr", "return", "figures", "exception")
+
+
+def test_request_to_json_round_trip():
+    r = Request(
+        runtime="python",
+        submission_dir="/box/submission",
+        module="submission",
+        obj_name="compute_area",
+        args=(3, 4),
+        kwargs={"unit": "cm"},
+        entries=("5\n",),
+        time_limit_seconds=2,
+        memory_limit_mb=512,
+        log_limit=4096,
+    )
+    encoded = r.to_json()
+    decoded = Request.from_json(encoded)
+    assert decoded == r
+
+
+def test_request_to_json_is_valid_json():
+    r = Request(
+        runtime="python",
+        submission_dir="/box/submission",
+        module="submission",
+        obj_name="main",
+    )
+    payload = json.loads(r.to_json())
+    assert payload["runtime"] == "python"
+    assert payload["module"] == "submission"
+    assert payload["protocol_version"] == PROTOCOL_VERSION
+
+
+def test_request_from_json_rejects_wrong_protocol_version():
+    bad = json.dumps(
+        {
+            "protocol_version": PROTOCOL_VERSION + 99,
+            "runtime": "python",
+            "submission_dir": "/box/submission",
+            "module": "submission",
+            "obj_name": "main",
+        }
+    )
+    with pytest.raises(SandboxException) as exc_info:
+        Request.from_json(bad)
+    assert "protocol_version" in str(exc_info.value)
+
+
+def test_request_from_json_rejects_missing_required_field():
+    bad = json.dumps({"protocol_version": PROTOCOL_VERSION, "runtime": "python"})
+    with pytest.raises(SandboxException):
+        Request.from_json(bad)
+
+
+def test_request_write_read_round_trip():
+    """`write_request` -> `read_request` should be lossless across a stream."""
+    r = Request(
+        runtime="python",
+        submission_dir="/box/submission",
+        module="m",
+        obj_name="f",
+        args=(1, 2),
+    )
+    buf = io.BytesIO()
+    write_request(buf, r)
+    buf.seek(0)
+    assert read_request(buf) == r
+
+
+def test_read_request_eof_returns_none():
+    assert read_request(io.BytesIO(b"")) is None
+
+
+# ---------------------------------------------------------------------------
+# Response envelope
+# ---------------------------------------------------------------------------
+
+
+def test_response_minimal_fields():
+    resp = Response(events=[])
+    assert resp.exception is None
+    assert resp.elapsed_seconds == 0.0
+
+
+def test_response_to_json_round_trip():
+    resp = Response(
+        events=[
+            Event(type="stdout", data="Enter a number: "),
+            Event(type="stdin", data="5\n"),
+            Event(type="return", value=25),
+        ],
+        elapsed_seconds=0.012,
+    )
+    decoded = Response.from_json(resp.to_json())
+    assert decoded == resp
+
+
+def test_response_serializes_exception_chain():
+    """Exception chains must round-trip with type/message/traceback per link."""
+    resp = Response(
+        events=[],
+        exception=SandboxException.serialized_chain(
+            [
+                {
+                    "type": "ValueError",
+                    "message": "bad input",
+                    "traceback": '  File "submission.py", line 3, in main\n    raise ValueError("bad input")\n',
+                },
+                {
+                    "type": "RuntimeError",
+                    "message": "wrapper",
+                    "traceback": '  File "submission.py", line 6, in caller\n    main()\n',
+                },
+            ]
+        ),
+    )
+    decoded = Response.from_json(resp.to_json())
+    assert decoded == resp
+    assert decoded.exception is not None
+    assert len(decoded.exception) == 2
+    assert decoded.exception[0]["type"] == "ValueError"
+
+
+def test_response_write_read_round_trip():
+    resp = Response(events=[Event(type="stdout", data="hi\n")], elapsed_seconds=0.5)
+    buf = io.BytesIO()
+    write_response(buf, resp)
+    buf.seek(0)
+    assert read_response(buf) == resp
+
+
+def test_read_response_eof_returns_none():
+    assert read_response(io.BytesIO(b"")) is None
+
+
+def test_response_from_json_rejects_wrong_protocol_version():
+    bad = json.dumps({"protocol_version": PROTOCOL_VERSION + 99, "events": []})
+    with pytest.raises(SandboxException):
+        Response.from_json(bad)
+
+
+# ---------------------------------------------------------------------------
+# Event
+# ---------------------------------------------------------------------------
+
+
+def test_event_to_dict_round_trip():
+    e = Event(type="stdout", data="hello\n")
+    assert Event.from_dict(e.to_dict()) == e
+
+
+def test_event_preserves_arbitrary_payload_fields():
+    """A figure event carries a `properties` dict; a return event carries `value`."""
+    fig = Event(
+        type="figure",
+        properties={"title": "My plot", "lines": [{"xdata": [1, 2], "ydata": [3, 4]}]},
+    )
+    assert Event.from_dict(fig.to_dict()) == fig
+
+    ret = Event(type="return", value={"answer": 42})
+    assert Event.from_dict(ret.to_dict()) == ret
+
+
+def test_event_attribute_access():
+    """Payload fields are reachable via attribute access at call sites."""
+    e = Event(type="stdout", data="hello\n")
+    assert e.data == "hello\n"
+
+
+def test_event_attribute_access_missing_raises():
+    e = Event(type="stdout", data="hi")
+    with pytest.raises(AttributeError):
+        _ = e.nonexistent_field
+
+
+def test_event_repr_contains_type_and_payload():
+    e = Event(type="return", value=42)
+    text = repr(e)
+    assert "return" in text
+    assert "42" in text
+
+
+def test_event_repr_with_no_payload():
+    """An Event without payload fields still has a readable repr."""
+    e = Event(type="ping")
+    text = repr(e)
+    assert "ping" in text
+
+
+def test_event_equality_against_non_event_returns_not_implemented():
+    """`Event.__eq__` against an unrelated object falls back cleanly."""
+    e = Event(type="stdout", data="hi")
+    assert (e == "not an event") is False
+    assert (e == 42) is False
+
+
+def test_request_from_json_rejects_malformed_json():
+    with pytest.raises(SandboxException) as exc_info:
+        Request.from_json("{not valid json")
+    assert "json" in str(exc_info.value).lower()
+
+
+def test_response_from_json_rejects_malformed_json():
+    with pytest.raises(SandboxException) as exc_info:
+        Response.from_json("{not valid json")
+    assert "json" in str(exc_info.value).lower()

--- a/tests/sandbox/test_protocol.py
+++ b/tests/sandbox/test_protocol.py
@@ -14,6 +14,7 @@ import pytest
 from generic_grader.sandbox.protocol import (
     PROTOCOL_VERSION,
     Event,
+    PatchSpec,
     Request,
     Response,
     SandboxException,
@@ -369,3 +370,105 @@ def test_response_from_json_rejects_malformed_json():
     with pytest.raises(SandboxException) as exc_info:
         Response.from_json("{not valid json")
     assert "json" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# PatchSpec
+# ---------------------------------------------------------------------------
+
+
+def test_patch_spec_noop_round_trip():
+    spec = PatchSpec(target="matplotlib.pyplot.show", kind="noop")
+    assert PatchSpec.from_dict(spec.to_dict()) == spec
+
+
+def test_patch_spec_iter_returns_round_trip():
+    spec = PatchSpec(
+        target="random.random",
+        kind="iter_returns",
+        values=[0.1, 0.2, 0.3],
+    )
+    round_tripped = PatchSpec.from_dict(spec.to_dict())
+    assert round_tripped == spec
+    assert round_tripped.values == [0.1, 0.2, 0.3]
+
+
+def test_patch_spec_raise_error_round_trip():
+    spec = PatchSpec(
+        target="turtle.done",
+        kind="raise_error",
+        error_qualname="generic_grader.utils.exceptions.TurtleDoneError",
+        patch_kwargs={"create": True},
+    )
+    round_tripped = PatchSpec.from_dict(spec.to_dict())
+    assert round_tripped == spec
+    assert round_tripped.patch_kwargs == {"create": True}
+
+
+def test_patch_spec_source_round_trip():
+    spec = PatchSpec(
+        target="falling.falling_dist",
+        kind="source",
+        source="def fake(time):\n    return time * 2\n",
+        name="fake",
+    )
+    assert PatchSpec.from_dict(spec.to_dict()) == spec
+
+
+def test_patch_spec_rejects_unknown_kind():
+    with pytest.raises(SandboxException, match="Unknown PatchSpec kind"):
+        PatchSpec(target="x", kind="bogus")
+
+
+def test_patch_spec_raise_error_requires_qualname():
+    with pytest.raises(SandboxException, match="error_qualname"):
+        PatchSpec(target="x", kind="raise_error")
+
+
+def test_patch_spec_source_requires_source_and_name():
+    with pytest.raises(SandboxException, match="source and name"):
+        PatchSpec(target="x", kind="source", source="def f(): pass")
+    with pytest.raises(SandboxException, match="source and name"):
+        PatchSpec(target="x", kind="source", name="f")
+
+
+def test_patch_spec_from_dict_tolerates_missing_optional_fields():
+    minimal = {"target": "m.show", "kind": "noop"}
+    spec = PatchSpec.from_dict(minimal)
+    assert spec.values == []
+    assert spec.error_qualname is None
+    assert spec.source is None
+    assert spec.name is None
+    assert spec.patch_kwargs == {}
+
+
+def test_request_round_trips_patch_specs():
+    specs = (
+        PatchSpec(target="matplotlib.pyplot.show", kind="noop"),
+        PatchSpec(
+            target="turtle.done",
+            kind="raise_error",
+            error_qualname="generic_grader.utils.exceptions.TurtleDoneError",
+            patch_kwargs={"create": True},
+        ),
+    )
+    req = Request(
+        runtime="python",
+        submission_dir="/box/submission",
+        module="submission",
+        obj_name="main",
+        patch_specs=specs,
+    )
+    round_tripped = Request.from_json(req.to_json())
+    assert round_tripped.patch_specs == specs
+
+
+def test_request_patch_specs_defaults_to_empty_tuple():
+    req = Request(
+        runtime="python",
+        submission_dir="/box/submission",
+        module="submission",
+        obj_name="main",
+    )
+    assert req.patch_specs == ()
+    assert Request.from_json(req.to_json()).patch_specs == ()

--- a/tests/sandbox/test_python_runtime.py
+++ b/tests/sandbox/test_python_runtime.py
@@ -992,3 +992,109 @@ def test_run_request_reverts_patches_after_call(submission_dir):
     run_request(_request(submission_dir, patch_specs=(spec,)))
     # After the request completes, builtins.exit is restored.
     assert _b.exit is original_exit
+
+
+# ---------------------------------------------------------------------------
+# Student-call SIGALRM time limit
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_enforces_student_call_time_limit_via_sigalrm(submission_dir):
+    """A student call that overruns ``time_limit_seconds`` raises
+    ``UserTimeoutError`` (legacy ``Options.time_limit`` semantics).
+
+    The alarm wraps only the call -- not interpreter startup, not
+    import.  We give a short student-code budget and a deliberately
+    slow ``main`` to force the alarm to fire deterministically.
+    """
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        import time
+
+        def main():
+            time.sleep(3)
+        """,
+    )
+    resp = run_request(_request(submission_dir, time_limit_seconds=0.05))
+    assert resp.exception is not None, "expected the alarm to fire"
+    head = resp.exception[0]
+    assert head["type"] == "UserTimeoutError"
+
+
+def test_run_request_disables_alarm_when_time_limit_non_positive(submission_dir):
+    """A non-positive ``time_limit_seconds`` disables the alarm.
+
+    This keeps the worker safe in pathological configurations and
+    documents the behavior of ``_student_call_time_limit(seconds<=0)``,
+    which is exercised by the early-return branch in the context
+    manager.
+    """
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return "ok"
+        """,
+    )
+    # A 0-second budget would kill *any* student code if the alarm
+    # were armed; we expect the disabled-alarm branch to let this run.
+    resp = run_request(_request(submission_dir, time_limit_seconds=0))
+    assert resp.exception is None
+
+
+def test_run_request_pluralizes_timeout_message_when_budget_is_one_second(
+    submission_dir,
+):
+    """``UserTimeoutError`` message says "1 second" (singular) when the
+    budget is exactly one second, matching the legacy non-sandbox
+    ``resource_limits.time_limit`` wording.
+    """
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        import time
+
+        def main():
+            time.sleep(3)
+        """,
+    )
+    resp = run_request(_request(submission_dir, time_limit_seconds=1))
+    assert resp.exception is not None
+    head = resp.exception[0]
+    assert head["type"] == "UserTimeoutError"
+    # The legacy phrasing is "1 second." (singular); anything else
+    # gets the plural form.
+    assert "1 second." in head["message"]
+
+
+def test_run_request_cancels_pending_alarm_when_call_returns_quickly(
+    submission_dir,
+):
+    """The alarm is cancelled on the way out of the call, even when
+    the student code returns well before the budget expires.
+
+    Without the cancellation in ``_student_call_time_limit``'s
+    ``finally`` block, a leftover ``setitimer`` could fire later (for
+    example during figure serialization) and turn a clean run into a
+    spurious ``UserTimeoutError``.
+    """
+    import signal as _signal
+
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return 1
+        """,
+    )
+    resp = run_request(_request(submission_dir, time_limit_seconds=5.0))
+    assert resp.exception is None
+    # The timer should be disarmed once the request returns.
+    remaining, interval = _signal.getitimer(_signal.ITIMER_REAL)
+    assert remaining == 0.0
+    assert interval == 0.0

--- a/tests/sandbox/test_python_runtime.py
+++ b/tests/sandbox/test_python_runtime.py
@@ -544,6 +544,71 @@ def test_run_request_restores_sys_path_and_modules(submission_dir):
 
 
 # ---------------------------------------------------------------------------
+# matplotlib fallbacks when matplotlib is unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_survives_missing_figure_serializer(submission_dir, monkeypatch):
+    """If the figure serializer can't be imported, the worker still returns.
+
+    This is the path the eventual Octave runtime will hit -- it shares
+    the worker scaffolding but ships without matplotlib.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "generic_grader.sandbox.figure_serializer":
+            raise ImportError("simulated missing matplotlib")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return 1
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    assert resp.exception is None
+    # No figure events because the serializer couldn't load.
+    assert not any(e.type == "figure" for e in resp.events)
+
+
+def test_run_request_survives_missing_pyplot_when_figures_disabled(
+    submission_dir, monkeypatch
+):
+    """The 'close figures' fallback also tolerates missing matplotlib."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "matplotlib.pyplot":
+            raise ImportError("simulated missing matplotlib")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return 1
+        """,
+    )
+    # 'figures' not in captures -> worker tries to close pyplot figures
+    # as cleanup; that import must be tolerated.
+    resp = run_request(_request(submission_dir, captures=("return", "exception")))
+    assert resp.exception is None
+
+
+# ---------------------------------------------------------------------------
 # _is_grader_frame helper
 # ---------------------------------------------------------------------------
 

--- a/tests/sandbox/test_python_runtime.py
+++ b/tests/sandbox/test_python_runtime.py
@@ -1,0 +1,600 @@
+"""Tests for the in-process Python runtime worker.
+
+These tests exercise `run_request` directly, without spawning a real
+sandboxed subprocess. The isolate-based runner (commit 4) calls the
+same `run_request` from inside the sandbox, so the contract tested
+here is exactly what the host sees over the wire.
+"""
+
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from generic_grader.sandbox.protocol import Request, Response
+from generic_grader.sandbox.python_runtime import _is_grader_frame, run_request
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def submission_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A clean directory to hold a single test submission module.
+
+    Each test writes its own module file into this directory and passes
+    the path to `run_request` via the `submission_dir` Request field.
+    """
+    # Make sure no stale import cache references a module with the same
+    # name from a previous test.
+    monkeypatch.delenv("PYTHONDONTWRITEBYTECODE", raising=False)
+    return tmp_path
+
+
+def _write(submission_dir: Path, name: str, source: str) -> None:
+    (submission_dir / name).write_text(textwrap.dedent(source))
+
+
+def _request(
+    submission_dir: Path,
+    module: str = "submission",
+    obj_name: str = "main",
+    **overrides,
+) -> Request:
+    base = dict(
+        runtime="python",
+        submission_dir=str(submission_dir),
+        module=module,
+        obj_name=obj_name,
+    )
+    base.update(overrides)
+    return Request(**base)
+
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_returns_response_instance(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return 42
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    assert isinstance(resp, Response)
+    assert resp.exception is None
+
+
+def test_run_request_captures_return_value(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return 42
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    returns = [e for e in resp.events if e.type == "return"]
+    assert len(returns) == 1
+    assert returns[0].value == 42
+
+
+def test_run_request_passes_args_and_kwargs(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main(a, b, *, scale=1):
+            return (a + b) * scale
+        """,
+    )
+    resp = run_request(_request(submission_dir, args=(3, 4), kwargs={"scale": 10}))
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value == 70
+
+
+# ---------------------------------------------------------------------------
+# stdout / stderr capture
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_captures_stdout(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            print("hello")
+            print("world")
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    stdout_text = "".join(e.data for e in resp.events if e.type == "stdout")
+    assert stdout_text == "hello\nworld\n"
+
+
+def test_run_request_captures_stderr(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        import sys
+        def main():
+            sys.stderr.write("oops\\n")
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    stderr_text = "".join(e.data for e in resp.events if e.type == "stderr")
+    assert "oops" in stderr_text
+
+
+def test_run_request_preserves_stdout_order_relative_to_stdin(submission_dir):
+    """stdout prompts and stdin entries interleave in the order they happen."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            a = input("first? ")
+            b = input("second? ")
+            return a + b
+        """,
+    )
+    resp = run_request(_request(submission_dir, entries=("X", "Y")))
+    types = [e.type for e in resp.events if e.type in ("stdout", "stdin", "return")]
+    # Expect: stdout("first? "), stdin("X"), stdout("second? "), stdin("Y"), return
+    assert types == ["stdout", "stdin", "stdout", "stdin", "return"]
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value == "XY"
+
+
+# ---------------------------------------------------------------------------
+# stdin / input() handling
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_input_pulls_from_entries(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            name = input("name? ")
+            return f"hi {name}"
+        """,
+    )
+    resp = run_request(_request(submission_dir, entries=("Alice",)))
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value == "hi Alice"
+    stdins = [e for e in resp.events if e.type == "stdin"]
+    assert [e.data for e in stdins] == ["Alice"]
+
+
+def test_run_request_input_emits_eof_when_entries_exhausted(submission_dir):
+    """Running out of entries should surface as an EOFError in the chain."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return input("more? ")
+        """,
+    )
+    resp = run_request(_request(submission_dir, entries=()))
+    assert resp.exception is not None
+    assert resp.exception[0]["type"] == "EOFError"
+
+
+def test_run_request_reports_unused_entries(submission_dir):
+    """If the student returns before consuming all entries, host needs to know."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            input("first ")
+            return "done"
+        """,
+    )
+    resp = run_request(_request(submission_dir, entries=("a", "b", "c")))
+    # One entry consumed leaves two leftover.
+    extras = [e for e in resp.events if e.type == "unused_entries"]
+    assert len(extras) == 1
+    assert extras[0].count == 2
+
+
+# ---------------------------------------------------------------------------
+# Exception chain (filtered to student frames only)
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_exception_chain_includes_type_and_message(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            raise ValueError("bad number")
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    assert resp.exception is not None
+    chain = resp.exception
+    assert chain[0]["type"] == "ValueError"
+    assert chain[0]["message"] == "bad number"
+
+
+def test_run_request_exception_traceback_includes_student_file(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def helper():
+            raise ZeroDivisionError("oh no")
+
+        def main():
+            helper()
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    tb = resp.exception[0]["traceback"]
+    assert "submission.py" in tb
+    # `helper` lives in the student file too.
+    assert "helper" in tb
+
+
+def test_run_request_exception_traceback_omits_grader_frames(submission_dir):
+    """Grader frames (worker, runtime) must not leak to the student.
+
+    The worker invokes the student callable through its own machinery,
+    so the raw traceback contains worker frames. Those frames live
+    inside `generic_grader`; they must be scrubbed from the serialized
+    traceback before it crosses the wire.
+    """
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            raise RuntimeError("oh no")
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    tb = resp.exception[0]["traceback"]
+    assert "generic_grader" not in tb
+    assert "python_runtime" not in tb
+
+
+def test_run_request_exception_chain_preserves_cause(submission_dir):
+    """Chained exceptions (`raise X from Y`) must show both links."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            try:
+                int("not a number")
+            except ValueError as e:
+                raise RuntimeError("wrap") from e
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    types = [link["type"] for link in resp.exception]
+    assert "RuntimeError" in types
+    assert "ValueError" in types
+
+
+def test_run_request_exception_chain_preserves_implicit_context(submission_dir):
+    """`__context__` (no explicit `from`) should still surface in the chain."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            try:
+                int("not a number")
+            except ValueError:
+                raise RuntimeError("wrap")
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    types = [link["type"] for link in resp.exception]
+    assert "RuntimeError" in types
+    assert "ValueError" in types
+
+
+# ---------------------------------------------------------------------------
+# Import phase vs call phase
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_marks_phase_for_import_failure(submission_dir):
+    """If the module fails to import, phase should be 'import'."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        raise SyntaxError("broken at module level")
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    assert resp.exception is not None
+    phases = [e for e in resp.events if e.type == "phase"]
+    assert phases[-1].name == "import"
+
+
+def test_run_request_marks_phase_for_call_failure(submission_dir):
+    """If the call raises, phase should be 'call'."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            raise ValueError("bad")
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    phases = [e for e in resp.events if e.type == "phase"]
+    assert phases[-1].name == "call"
+
+
+def test_run_request_phase_completed_on_success(submission_dir):
+    """Success path emits a final phase=='completed'."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return None
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    phases = [e for e in resp.events if e.type == "phase"]
+    assert phases[-1].name == "completed"
+
+
+def test_run_request_module_missing_is_import_phase(submission_dir):
+    """A missing module raises ModuleNotFoundError in the import phase."""
+    resp = run_request(_request(submission_dir, module="not_real"))
+    assert resp.exception is not None
+    assert resp.exception[0]["type"] == "ModuleNotFoundError"
+    phases = [e for e in resp.events if e.type == "phase"]
+    assert phases[-1].name == "import"
+
+
+def test_run_request_obj_missing_is_import_phase(submission_dir):
+    """A missing attribute on an otherwise-good module is still import-phase."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def something_else():
+            pass
+        """,
+    )
+    resp = run_request(_request(submission_dir, obj_name="main"))
+    assert resp.exception is not None
+    assert resp.exception[0]["type"] == "AttributeError"
+    phases = [e for e in resp.events if e.type == "phase"]
+    assert phases[-1].name == "import"
+
+
+# ---------------------------------------------------------------------------
+# Captures whitelist
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_captures_can_skip_stdout(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            print("noisy")
+            return 1
+        """,
+    )
+    resp = run_request(_request(submission_dir, captures=("return", "exception")))
+    assert not any(e.type == "stdout" for e in resp.events)
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value == 1
+
+
+def test_run_request_captures_can_skip_return(submission_dir):
+    """If 'return' is not in captures, no return event is emitted."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return 99
+        """,
+    )
+    resp = run_request(_request(submission_dir, captures=("stdout", "exception")))
+    assert not any(e.type == "return" for e in resp.events)
+
+
+# ---------------------------------------------------------------------------
+# Return value JSON-safety
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_non_serializable_return_value_uses_repr(submission_dir):
+    """Custom objects can't go over the wire; fall back to repr()."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        class Widget:
+            def __repr__(self):
+                return "<Widget id=7>"
+
+        def main():
+            return Widget()
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].non_serializable is True
+    assert returns[0].repr == "<Widget id=7>"
+
+
+def test_run_request_serializable_return_value_does_not_set_repr_flag(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return {"answer": 42, "items": [1, 2, 3]}
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    ret_event = next(e for e in resp.events if e.type == "return")
+    assert ret_event.value == {"answer": 42, "items": [1, 2, 3]}
+    assert "non_serializable" not in ret_event.extra
+
+
+# ---------------------------------------------------------------------------
+# fixed_time
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_fixed_time_freezes_clock(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        from datetime import datetime
+        def main():
+            return datetime.now().isoformat()
+        """,
+    )
+    resp = run_request(_request(submission_dir, fixed_time="2025-01-01 12:00:00"))
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value.startswith("2025-01-01T12:00:00")
+
+
+# ---------------------------------------------------------------------------
+# Elapsed time
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_records_elapsed_seconds(submission_dir):
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return 1
+        """,
+    )
+    resp = run_request(_request(submission_dir))
+    assert resp.elapsed_seconds >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Working directory and sys.path isolation
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_uses_submission_dir_as_cwd(submission_dir):
+    """Files created at relative paths must land inside the submission dir."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            with open("hello.txt", "w") as f:
+                f.write("ok")
+            return "written"
+        """,
+    )
+    run_request(_request(submission_dir))
+    assert (submission_dir / "hello.txt").is_file()
+    assert (submission_dir / "hello.txt").read_text() == "ok"
+    # Worker must restore cwd on the way out so the host process is unaffected.
+    assert os.getcwd() != str(submission_dir)
+
+
+def test_run_request_restores_sys_path_and_modules(submission_dir):
+    """After a run, sys.path and sys.modules should not retain the submission."""
+    import sys
+
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return 1
+        """,
+    )
+    before_path = list(sys.path)
+    before_modules = set(sys.modules)
+    run_request(_request(submission_dir))
+    assert sys.path == before_path
+    assert "submission" not in (set(sys.modules) - before_modules)
+
+
+# ---------------------------------------------------------------------------
+# _is_grader_frame helper
+# ---------------------------------------------------------------------------
+
+
+def test_is_grader_frame_empty_filename():
+    """Frames synthesized by `exec` may carry an empty filename."""
+    assert _is_grader_frame("") is False
+
+
+def test_is_grader_frame_unresolvable_path(monkeypatch):
+    """Path.resolve() raising must not crash the serializer."""
+    from pathlib import Path as _Path
+
+    original_resolve = _Path.resolve
+
+    def boom(self, *args, **kwargs):
+        raise OSError("cannot resolve")
+
+    monkeypatch.setattr(_Path, "resolve", boom)
+    try:
+        # Should fall back to the raw filename without raising.
+        assert _is_grader_frame("/some/student/path.py") is False
+    finally:
+        monkeypatch.setattr(_Path, "resolve", original_resolve)
+
+
+def test_run_request_two_modules_with_same_name_do_not_share_state(
+    submission_dir, tmp_path
+):
+    """Two consecutive runs with different submission dirs must not alias."""
+    other = tmp_path / "other"
+    other.mkdir()
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            return "first"
+        """,
+    )
+    _write(
+        other,
+        "submission.py",
+        """
+        def main():
+            return "second"
+        """,
+    )
+    r1 = run_request(_request(submission_dir))
+    r2 = run_request(_request(other))
+    v1 = next(e for e in r1.events if e.type == "return").value
+    v2 = next(e for e in r2.events if e.type == "return").value
+    assert v1 == "first"
+    assert v2 == "second"

--- a/tests/sandbox/test_python_runtime.py
+++ b/tests/sandbox/test_python_runtime.py
@@ -735,3 +735,260 @@ def test_exception_chain_capped_at_max_links():
 
     chain = _serialize_exception_chain(head)
     assert len(chain) == _MAX_EXCEPTION_CHAIN_LINKS
+
+
+# ---------------------------------------------------------------------------
+# PatchSpec reconstruction (commit 5b)
+# ---------------------------------------------------------------------------
+
+
+from generic_grader.sandbox.protocol import PatchSpec  # noqa: E402
+from generic_grader.sandbox.python_runtime import (  # noqa: E402
+    _build_mock_from_spec,
+    _enter_patches_from_specs,
+    _resolve_error_class,
+    _target_basename,
+)
+
+
+def test_target_basename_strips_dotted_prefix():
+    assert _target_basename("submission.input") == "input"
+    assert _target_basename("a.b.c.func") == "func"
+
+
+def test_resolve_error_class_returns_exception_subclass():
+    from generic_grader.utils.exceptions import ExitError
+
+    resolved = _resolve_error_class("generic_grader.utils.exceptions.ExitError")
+    assert resolved is ExitError
+
+
+def test_resolve_error_class_rejects_malformed_qualname():
+    with pytest.raises(ValueError, match="Invalid error_qualname"):
+        _resolve_error_class("not-a-qualname")
+
+
+def test_resolve_error_class_rejects_non_exception():
+    """Anything other than a BaseException subclass is rejected."""
+    # `os.path` resolves but is a module, not an exception class.
+    with pytest.raises(TypeError, match="not an exception class"):
+        _resolve_error_class("os.path")
+
+
+def test_build_mock_from_spec_noop_returns_none_and_swallows_args():
+    spec = PatchSpec(target="submission.do_thing", kind="noop")
+    mock = _build_mock_from_spec(spec)
+    assert mock() is None
+    assert mock(1, 2, k=3) is None
+
+
+def test_build_mock_from_spec_iter_returns_values_then_raises():
+    from generic_grader.utils.exceptions import ExcessFunctionCallError
+
+    spec = PatchSpec(target="submission.input", kind="iter_returns", values=["a", "b"])
+    mock = _build_mock_from_spec(spec)
+    assert mock() == "a"
+    assert mock("ignored prompt") == "b"
+    with pytest.raises(ExcessFunctionCallError):
+        mock()
+
+
+def test_build_mock_from_spec_raise_error_raises_with_call_str():
+    from generic_grader.utils.exceptions import ExitError
+
+    spec = PatchSpec(
+        target="builtins.exit",
+        kind="raise_error",
+        error_qualname="generic_grader.utils.exceptions.ExitError",
+    )
+    mock = _build_mock_from_spec(spec)
+    with pytest.raises(ExitError) as exc_info:
+        mock(1, key="val")
+    assert "exit" in str(exc_info.value)
+
+
+def test_build_mock_from_spec_source_execs_in_empty_namespace():
+    src = textwrap.dedent(
+        """
+        def fake_falling_dist(time):
+            return (time * 1234567.89) % 125
+        """
+    )
+    spec = PatchSpec(
+        target="submission.falling_dist",
+        kind="source",
+        source=src,
+        name="fake_falling_dist",
+    )
+    mock = _build_mock_from_spec(spec)
+    # Pure-arithmetic body works without any host globals leaking in.
+    assert mock(0) == 0.0
+    assert mock(2) == (2 * 1234567.89) % 125
+
+
+def test_build_mock_from_spec_source_rejects_missing_name():
+    """If the source doesn't define a callable matching `name`, fail."""
+    spec = PatchSpec(
+        target="submission.x",
+        kind="source",
+        source="x = 7\n",  # no callable named `wrong_name`
+        name="wrong_name",
+    )
+    with pytest.raises(ValueError, match="did not define a callable"):
+        _build_mock_from_spec(spec)
+
+
+# ---- End-to-end through run_request -------------------------------------
+
+
+def test_run_request_applies_noop_patch_during_call(submission_dir):
+    """A `noop` patch_spec replaces the target inside the worker."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        import os
+        def main():
+            # If the patch worked, this call is a noop and we return 1.
+            # If it didn't, calling exit() would terminate the process.
+            exit(99)
+            return 1
+        """,
+    )
+    spec = PatchSpec(target="builtins.exit", kind="noop")
+    resp = run_request(_request(submission_dir, patch_specs=(spec,)))
+    assert resp.exception is None
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value == 1
+
+
+def test_run_request_applies_iter_returns_patch(submission_dir):
+    """A patched submission.greet returns successive values from the spec."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def greet():
+            return "real"
+        def main():
+            return [greet(), greet()]
+        """,
+    )
+    spec = PatchSpec(
+        target="submission.greet", kind="iter_returns", values=["hi", "bye"]
+    )
+    resp = run_request(_request(submission_dir, patch_specs=(spec,)))
+    assert resp.exception is None
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value == ["hi", "bye"]
+
+
+def test_run_request_applies_raise_error_patch(submission_dir):
+    """A `raise_error` patch raises the resolved class on call."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def main():
+            exit(0)
+        """,
+    )
+    spec = PatchSpec(
+        target="builtins.exit",
+        kind="raise_error",
+        error_qualname="generic_grader.utils.exceptions.ExitError",
+    )
+    resp = run_request(_request(submission_dir, patch_specs=(spec,)))
+    assert resp.exception is not None
+    assert resp.exception[0]["type"] == "ExitError"
+
+
+def test_run_request_applies_source_patch(submission_dir):
+    """A `source` patch defines a callable that replaces the target."""
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        def falling_dist(t):
+            # Real implementation would compute physics; we expect the
+            # patched fake to be called instead.
+            raise RuntimeError("real falling_dist should not run")
+
+        def main():
+            return [falling_dist(0), falling_dist(2)]
+        """,
+    )
+    src = textwrap.dedent(
+        """
+        def fake_falling_dist(time):
+            return (time * 1234567.89) % 125
+        """
+    )
+    spec = PatchSpec(
+        target="submission.falling_dist",
+        kind="source",
+        source=src,
+        name="fake_falling_dist",
+    )
+    resp = run_request(_request(submission_dir, patch_specs=(spec,)))
+    assert resp.exception is None
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value == [0.0, (2 * 1234567.89) % 125]
+
+
+def test_run_request_patches_active_during_module_import(submission_dir):
+    """Module-top-level code observing the patched target sees the mock.
+
+    This catches the bug where patches were applied only around the
+    call (so module-level invocations of the target would see the
+    real attribute).
+    """
+    _write(
+        submission_dir,
+        "submission.py",
+        """
+        # Top-level call captures the patched value at import time.
+        TOP_LEVEL = exit  # bound reference at module load
+        def main():
+            return TOP_LEVEL.__name__
+        """,
+    )
+    # Replace `builtins.exit` with a noop so the top-level binding
+    # picks up the patched function.
+    spec = PatchSpec(target="builtins.exit", kind="noop")
+    resp = run_request(_request(submission_dir, patch_specs=(spec,)))
+    assert resp.exception is None
+    returns = [e for e in resp.events if e.type == "return"]
+    # The patched noop is a locally-defined function named `_noop`.
+    assert returns[0].value == "_noop"
+
+
+def test_run_request_reports_patch_target_validation_error(submission_dir):
+    """A malformed patch target surfaces as a structured exception."""
+    _write(submission_dir, "submission.py", "def main(): return 1\n")
+    # ``target`` has no dot, so it can't be a dotted patch path.
+    spec = PatchSpec(target="invalidtarget", kind="noop")
+    resp = run_request(_request(submission_dir, patch_specs=(spec,)))
+    assert resp.exception is not None
+    assert resp.exception[0]["type"] == "ValueError"
+    assert "Invalid patch target" in resp.exception[0]["message"]
+
+
+def test_enter_patches_from_specs_with_empty_tuple_is_noop():
+    """No specs => stack unchanged; no exceptions."""
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        _enter_patches_from_specs(stack, ())
+
+
+def test_run_request_reverts_patches_after_call(submission_dir):
+    """Patches applied for one request don't leak into the next."""
+    import builtins as _b
+
+    original_exit = _b.exit
+    _write(submission_dir, "submission.py", "def main(): return 1\n")
+    spec = PatchSpec(target="builtins.exit", kind="noop")
+    run_request(_request(submission_dir, patch_specs=(spec,)))
+    # After the request completes, builtins.exit is restored.
+    assert _b.exit is original_exit

--- a/tests/sandbox/test_python_runtime.py
+++ b/tests/sandbox/test_python_runtime.py
@@ -179,7 +179,14 @@ def test_run_request_input_pulls_from_entries(submission_dir):
 
 
 def test_run_request_input_emits_eof_when_entries_exhausted(submission_dir):
-    """Running out of entries should surface as an EOFError in the chain."""
+    """Running out of entries should surface as an EOFError in the chain.
+
+    The internal StopIteration that drives the responder must NOT leak
+    into the serialized exception chain -- real CPython ``input()``
+    raises a bare EOFError, and the grader's existing exception
+    classification (importer.py walks ``__cause__``/``__context__``)
+    would be confused by a chained StopIteration.
+    """
     _write(
         submission_dir,
         "submission.py",
@@ -191,6 +198,8 @@ def test_run_request_input_emits_eof_when_entries_exhausted(submission_dir):
     resp = run_request(_request(submission_dir, entries=()))
     assert resp.exception is not None
     assert resp.exception[0]["type"] == "EOFError"
+    # No StopIteration in the chain -- we raise ``from None``.
+    assert all(link["type"] != "StopIteration" for link in resp.exception)
 
 
 def test_run_request_reports_unused_entries(submission_dir):
@@ -663,3 +672,66 @@ def test_run_request_two_modules_with_same_name_do_not_share_state(
     v2 = next(e for e in r2.events if e.type == "return").value
     assert v1 == "first"
     assert v2 == "second"
+
+
+# ---------------------------------------------------------------------------
+# Defensive input validation
+# ---------------------------------------------------------------------------
+
+
+def test_run_request_rejects_invalid_module_name(submission_dir):
+    """Worker won't pass arbitrary strings to ``importlib.import_module``.
+
+    Defense in depth: the host always constructs valid identifiers,
+    but tests call ``run_request`` directly and the worker shouldn't
+    silently accept a malformed module name.
+    """
+    resp = run_request(_request(submission_dir, module="bad/path.py"))
+    assert resp.exception is not None
+    assert resp.exception[0]["type"] == "ValueError"
+    assert "module name" in resp.exception[0]["message"].lower()
+
+
+def test_run_request_rejects_invalid_obj_name(submission_dir):
+    """Same guard applies to the attribute name lookup."""
+    _write(submission_dir, "submission.py", "def main():\n    return None\n")
+    resp = run_request(_request(submission_dir, obj_name="main; rm -rf /"))
+    assert resp.exception is not None
+    assert resp.exception[0]["type"] == "ValueError"
+    assert "object name" in resp.exception[0]["message"].lower()
+
+
+def test_run_request_accepts_dotted_module_name(submission_dir):
+    """Dotted package paths remain valid."""
+    pkg = submission_dir / "mypkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    _write(pkg, "submission.py", "def main():\n    return 42\n")
+    resp = run_request(_request(submission_dir, module="mypkg.submission"))
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value == 42
+
+
+# ---------------------------------------------------------------------------
+# Exception-chain depth cap
+# ---------------------------------------------------------------------------
+
+
+def test_exception_chain_capped_at_max_links():
+    """Chains longer than the cap are truncated, not infinite-looped."""
+    from generic_grader.sandbox.python_runtime import (
+        _MAX_EXCEPTION_CHAIN_LINKS,
+        _serialize_exception_chain,
+    )
+
+    # Build a chain longer than the cap.
+    root = ValueError("root")
+    head: BaseException = root
+    for i in range(_MAX_EXCEPTION_CHAIN_LINKS + 5):
+        try:
+            raise RuntimeError(f"link {i}") from head
+        except RuntimeError as e:
+            head = e
+
+    chain = _serialize_exception_chain(head)
+    assert len(chain) == _MAX_EXCEPTION_CHAIN_LINKS

--- a/tests/sandbox/test_routing.py
+++ b/tests/sandbox/test_routing.py
@@ -1,0 +1,441 @@
+"""End-to-end routing tests for `Options.use_sandbox=True`.
+
+These tests don't spin up a real isolate worker -- they monkeypatch
+the integration module's entry points to inject pre-built
+`SandboxRunResult` instances.  That lets us assert the routing inside
+`Importer.import_obj` / `__User__.call_obj` translates structured
+sandbox outcomes into the same student-facing failure messages the
+legacy in-process path produces.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import pytest
+
+from generic_grader.sandbox.integration import SandboxRunResult
+from generic_grader.utils.exceptions import (
+    EndOfInputError,
+    ExtraEntriesError,
+    UserInitializationError,
+)
+from generic_grader.utils.importer import SANDBOX_OBJ_SENTINEL, Importer
+from generic_grader.utils.options import Options
+from generic_grader.utils.user import RefUser, SubUser
+
+
+class FakeTest(unittest.TestCase):
+    """Stand-in TestCase mirroring the harness `Importer`/`User` expect."""
+
+
+def _opts(**overrides: Any) -> Options:
+    base: dict[str, Any] = dict(use_sandbox=True, sub_module="submission")
+    base.update(overrides)
+    return Options(**base)
+
+
+def _patch_import(
+    monkeypatch: pytest.MonkeyPatch, result: SandboxRunResult
+) -> list[tuple]:
+    """Replace `sandbox_import_obj` with a stub returning `result`.
+
+    Returns the list of `(module, options)` calls observed so tests
+    can assert the routing forwarded the right inputs.
+    """
+    calls: list[tuple] = []
+
+    def _stub(module, options, **kwargs):
+        calls.append((module, options))
+        return result
+
+    monkeypatch.setattr("generic_grader.sandbox.integration.sandbox_import_obj", _stub)
+    return calls
+
+
+def _patch_call(
+    monkeypatch: pytest.MonkeyPatch, result: SandboxRunResult
+) -> list[tuple]:
+    calls: list[tuple] = []
+
+    def _stub(module, options, **kwargs):
+        calls.append((module, options))
+        return result
+
+    monkeypatch.setattr("generic_grader.sandbox.integration.sandbox_call_obj", _stub)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Importer routing
+# ---------------------------------------------------------------------------
+
+
+def test_importer_routes_to_sandbox_when_use_sandbox_set(monkeypatch):
+    calls = _patch_import(monkeypatch, SandboxRunResult(exception=None))
+    obj = Importer.import_obj(FakeTest(), "submission", _opts(obj_name="main"))
+    assert obj is SANDBOX_OBJ_SENTINEL
+    assert calls == [("submission", _opts(obj_name="main"))] or len(calls) == 1
+
+
+def test_importer_legacy_path_still_works_when_use_sandbox_false(fix_syspath):
+    """When use_sandbox is False, the in-process path runs."""
+    (fix_syspath / "fake_module.py").write_text("fake_func = lambda: None")
+    obj = Importer.import_obj(FakeTest(), "fake_module", Options(obj_name="fake_func"))
+    # Real callable, not the sandbox sentinel.
+    assert obj is not SANDBOX_OBJ_SENTINEL
+    assert callable(obj)
+
+
+def test_importer_sandbox_reports_stuck_at_input(monkeypatch):
+    """Module-level input() in import phase classifies as EndOfInputError."""
+    _patch_import(
+        monkeypatch,
+        SandboxRunResult(consumed_input_during_import=True),
+    )
+    test = FakeTest()
+    with pytest.raises(EndOfInputError) as exc_info:
+        Importer.import_obj(test, "submission", _opts(obj_name="main"))
+    assert "Stuck at call to `input()`" in str(exc_info.value)
+    assert test.failureException is EndOfInputError
+
+
+def test_importer_sandbox_reports_attribute_error(monkeypatch):
+    _patch_import(
+        monkeypatch,
+        SandboxRunResult(
+            exception=[
+                {
+                    "type": "AttributeError",
+                    "message": "module 'submission' has no attribute 'main'",
+                    "traceback": "",
+                }
+            ]
+        ),
+    )
+    test = FakeTest()
+    with pytest.raises(AttributeError) as exc_info:
+        Importer.import_obj(test, "submission", _opts(obj_name="main"))
+    assert "Unable to import `main`" in str(exc_info.value)
+    assert test.failureException is AttributeError
+
+
+def test_importer_sandbox_reports_module_not_found_for_target_module(monkeypatch):
+    _patch_import(
+        monkeypatch,
+        SandboxRunResult(
+            exception=[
+                {
+                    "type": "ModuleNotFoundError",
+                    "message": "No module named 'submission'",
+                    "traceback": "",
+                }
+            ]
+        ),
+    )
+    test = FakeTest()
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        Importer.import_obj(test, "submission", _opts(obj_name="main"))
+    msg = str(exc_info.value)
+    assert "Unable to import `submission`" in msg
+    assert "submitted a module named `submission`" in msg
+
+
+def test_importer_sandbox_reports_module_not_found_for_dependency(monkeypatch):
+    """When the submitted module imports a missing dependency, hint differs."""
+    _patch_import(
+        monkeypatch,
+        SandboxRunResult(
+            exception=[
+                {
+                    "type": "ModuleNotFoundError",
+                    "message": "No module named 'numpy'",
+                    "traceback": "",
+                }
+            ]
+        ),
+    )
+    test = FakeTest()
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        Importer.import_obj(test, "submission", _opts(obj_name="main"))
+    msg = str(exc_info.value)
+    assert "Your `submission` module imports `numpy`" in msg
+
+
+def test_importer_sandbox_reports_module_not_found_walks_deepest(monkeypatch):
+    """Multi-step chain: deepest ModuleNotFoundError wins."""
+    _patch_import(
+        monkeypatch,
+        SandboxRunResult(
+            exception=[
+                {
+                    "type": "ModuleNotFoundError",
+                    "message": "No module named 'pkg.subpkg'",
+                    "traceback": "",
+                },
+                {
+                    "type": "ModuleNotFoundError",
+                    "message": "No module named 'pkg.subpkg.inner'",
+                    "traceback": "",
+                },
+            ]
+        ),
+    )
+    test = FakeTest()
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        Importer.import_obj(test, "submission", _opts(obj_name="main"))
+    # The hint should reference the deepest missing name.
+    assert "pkg.subpkg.inner" in str(exc_info.value)
+
+
+def test_importer_sandbox_generic_fallback_uses_chain_message(monkeypatch):
+    _patch_import(
+        monkeypatch,
+        SandboxRunResult(
+            exception=[
+                {
+                    "type": "ValueError",
+                    "message": "bad input",
+                    "traceback": '  File "submission.py", line 1\n    foo()\n',
+                }
+            ]
+        ),
+    )
+    test = FakeTest()
+    with pytest.raises(ValueError) as exc_info:
+        Importer.import_obj(test, "submission", _opts(obj_name="main"))
+    msg = str(exc_info.value)
+    assert "ValueError" in msg
+    assert "bad input" in msg
+    assert "Error while importing `main`" in msg
+
+
+def test_importer_sandbox_generic_fallback_without_traceback(monkeypatch):
+    """A chain with no traceback text still produces a readable message."""
+    _patch_import(
+        monkeypatch,
+        SandboxRunResult(
+            exception=[{"type": "RuntimeError", "message": "oops", "traceback": ""}]
+        ),
+    )
+    test = FakeTest()
+    with pytest.raises(RuntimeError) as exc_info:
+        Importer.import_obj(test, "submission", _opts(obj_name="main"))
+    assert "RuntimeError" in str(exc_info.value)
+
+
+def test_importer_sandbox_generic_fallback_empty_chain(monkeypatch):
+    """If the chain is somehow empty but classifier returns a type, still fail."""
+    # Pre-classified: caller forces an Exception even with no chain.
+    # We achieve this by sending an unknown type that resolves to Exception.
+    _patch_import(
+        monkeypatch,
+        SandboxRunResult(exception=[{"type": "MysteryError"}]),
+    )
+    test = FakeTest()
+    with pytest.raises(Exception):
+        Importer.import_obj(test, "submission", _opts(obj_name="main"))
+
+
+def test_extract_missing_module_falls_back_to_target_when_no_match():
+    """No ModuleNotFoundError entries -> return the original module name."""
+    result = SandboxRunResult(exception=[{"type": "ValueError", "message": ""}])
+    assert Importer._extract_missing_module(result, "submission") == "submission"
+
+
+def test_extract_missing_module_handles_missing_message():
+    """A ModuleNotFoundError without the canonical text falls through."""
+    result = SandboxRunResult(
+        exception=[{"type": "ModuleNotFoundError", "message": ""}]
+    )
+    assert Importer._extract_missing_module(result, "submission") == "submission"
+
+
+# ---------------------------------------------------------------------------
+# User routing (call_obj)
+# ---------------------------------------------------------------------------
+
+
+def _make_subuser(monkeypatch: pytest.MonkeyPatch, options: Options) -> SubUser:
+    """Build a SubUser whose import phase is stubbed to succeed."""
+    _patch_import(monkeypatch, SandboxRunResult(exception=None))
+    return SubUser(FakeTest(), options)
+
+
+def test_user_calls_sandbox_path_when_use_sandbox_set(monkeypatch):
+    """call_obj delegates to sandbox_call_obj when the flag is set."""
+    user = _make_subuser(monkeypatch, _opts())
+    call_calls = _patch_call(
+        monkeypatch,
+        SandboxRunResult(exception=None, return_value=42),
+    )
+    returned = user.call_obj()
+    assert returned == 42
+    assert len(call_calls) == 1
+    assert call_calls[0][0] == "submission"
+
+
+def test_user_replays_log_into_logio(monkeypatch):
+    user = _make_subuser(monkeypatch, _opts(entries=("ans",)))
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(
+            exception=None,
+            log="prompt> ans\ndone\n",
+            interactions=[0, 8],
+            return_value=None,
+        ),
+    )
+    user.call_obj()
+    assert user.log.getvalue() == "prompt> ans\ndone\n"
+    assert user.interactions == [0, 8]
+
+
+def test_user_sandbox_returns_repr_for_non_serializable_value(monkeypatch):
+    user = _make_subuser(monkeypatch, _opts())
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(
+            exception=None,
+            return_non_serializable=True,
+            return_repr="<CustomObj>",
+        ),
+    )
+    returned = user.call_obj()
+    assert returned == "<CustomObj>"
+    assert user.returned_values == "<CustomObj>"
+
+
+def test_user_sandbox_raises_extra_entries_error_on_leftover(monkeypatch):
+    user = _make_subuser(monkeypatch, _opts(entries=("a", "b")))
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(exception=None, unused_entries=1),
+    )
+    with pytest.raises(ExtraEntriesError) as exc_info:
+        user.call_obj()
+    msg = str(exc_info.value)
+    assert "ended before the user finished entering input" in msg
+
+
+def test_user_sandbox_propagates_value_error(monkeypatch):
+    user = _make_subuser(monkeypatch, _opts())
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(
+            exception=[
+                {
+                    "type": "ValueError",
+                    "message": "bad",
+                    "traceback": '  File "submission.py", line 2\n    main()\n',
+                }
+            ]
+        ),
+    )
+    with pytest.raises(ValueError) as exc_info:
+        user.call_obj()
+    msg = str(exc_info.value)
+    assert "ValueError" in msg
+    assert "bad" in msg
+
+
+def test_user_sandbox_uses_safe_key_error(monkeypatch):
+    """KeyError gets wrapped in SafeKeyError (mirrors legacy path)."""
+    user = _make_subuser(monkeypatch, _opts())
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(
+            exception=[{"type": "KeyError", "message": "missing", "traceback": ""}]
+        ),
+    )
+    with pytest.raises(KeyError):
+        user.call_obj()
+    # The wrapper is named "KeyError" but is a safe subclass.
+    assert user.test.failureException.__name__ == "KeyError"
+
+
+def test_user_sandbox_failure_includes_log_when_nonempty(monkeypatch):
+    """A failure message appends the IO log when there's something to show."""
+    user = _make_subuser(monkeypatch, _opts())
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(
+            exception=[{"type": "ValueError", "message": "x", "traceback": ""}],
+            log="some output\n",
+            interactions=[0],
+        ),
+    )
+    with pytest.raises(ValueError) as exc_info:
+        user.call_obj()
+    assert "Input/Output Log" in str(exc_info.value)
+
+
+def test_user_sandbox_failure_skips_log_when_empty(monkeypatch):
+    """No log -> no log section appended."""
+    user = _make_subuser(monkeypatch, _opts())
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(
+            exception=[{"type": "ValueError", "message": "x", "traceback": ""}],
+            log="",
+        ),
+    )
+    with pytest.raises(ValueError) as exc_info:
+        user.call_obj()
+    assert "Input/Output Log" not in str(exc_info.value)
+
+
+def test_user_sandbox_legacy_path_still_works(fix_syspath):
+    """use_sandbox=False -> in-process path runs (sanity check)."""
+    (fix_syspath / "fake_module.py").write_text(
+        "def fake_func():\n    print('hi')\n    return 7\n"
+    )
+    opts = Options(sub_module="fake_module", obj_name="fake_func", use_sandbox=False)
+    user = SubUser(FakeTest(), opts)
+    returned = user.call_obj()
+    assert returned == 7
+    assert "hi" in user.log.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# RefUser parity
+# ---------------------------------------------------------------------------
+
+
+def test_refuser_routes_to_sandbox_with_ref_module(monkeypatch):
+    """RefUser uses options.ref_module as the target."""
+    _patch_import(monkeypatch, SandboxRunResult(exception=None))
+    call_calls = _patch_call(
+        monkeypatch,
+        SandboxRunResult(exception=None, return_value="ref"),
+    )
+    opts = _opts(ref_module="tests.reference", sub_module="submission")
+    user = RefUser(FakeTest(), opts)
+    user.call_obj()
+    assert call_calls[0][0] == "tests.reference"
+
+
+# ---------------------------------------------------------------------------
+# Misc edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_user_initialization_requires_module():
+    """Direct __User__ instantiation without a module subclass still errors."""
+    from generic_grader.utils.user import __User__
+
+    with pytest.raises(UserInitializationError):
+        __User__(FakeTest(), Options(use_sandbox=True))
+
+
+def test_user_sandbox_call_obj_no_log_or_interactions_when_empty(monkeypatch):
+    """An empty log and a single zero interaction is the no-op replay."""
+    user = _make_subuser(monkeypatch, _opts())
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(exception=None, log="", interactions=[0]),
+    )
+    user.call_obj()
+    assert user.log.getvalue() == ""
+    assert user.interactions == [0]

--- a/tests/sandbox/test_routing.py
+++ b/tests/sandbox/test_routing.py
@@ -467,3 +467,19 @@ def test_user_sandbox_does_not_set_figures_when_empty(monkeypatch):
     )
     user.call_obj()
     assert not hasattr(user.test, "_sandbox_figures")
+
+
+def test_user_sandbox_warns_when_obj_set_outside_sentinel(monkeypatch):
+    """If a caller stamps ``self.obj`` with anything other than the
+    sentinel, the sandbox path still completes successfully but emits
+    a UserWarning so the misuse is visible in test logs.  The sandbox
+    re-resolves the target inside the worker; ``self.obj`` is ignored.
+    """
+    user = _make_subuser(monkeypatch, _opts())
+    user.obj = object()  # bypass the sentinel stamp
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(exception=None, return_value=1),
+    )
+    with pytest.warns(UserWarning, match="sandbox import path was bypassed"):
+        user.call_obj()

--- a/tests/sandbox/test_routing.py
+++ b/tests/sandbox/test_routing.py
@@ -439,3 +439,31 @@ def test_user_sandbox_call_obj_no_log_or_interactions_when_empty(monkeypatch):
     user.call_obj()
     assert user.log.getvalue() == ""
     assert user.interactions == [0]
+
+
+def test_user_sandbox_attaches_figures_to_test(monkeypatch):
+    """When the sandbox returns figures, they're handed to the test.
+
+    The plot helpers in ``utils/plot.py`` look for
+    ``test._sandbox_figures``; this test confirms the user wires that
+    attribute up after a successful sandbox call.
+    """
+    user = _make_subuser(monkeypatch, _opts())
+    figures = [{"format": "matplotlib-figure", "version": 1, "axes": [{"title": "Hi"}]}]
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(exception=None, return_value=None, figures=figures),
+    )
+    user.call_obj()
+    assert user.test._sandbox_figures == figures
+
+
+def test_user_sandbox_does_not_set_figures_when_empty(monkeypatch):
+    """No figures -> no attribute set on the test (live plt.gcf() path)."""
+    user = _make_subuser(monkeypatch, _opts())
+    _patch_call(
+        monkeypatch,
+        SandboxRunResult(exception=None, return_value=None, figures=[]),
+    )
+    user.call_obj()
+    assert not hasattr(user.test, "_sandbox_figures")

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -147,18 +147,19 @@ def test_run_argv_includes_required_bind_mounts(tmp_path):
         meta_path="/tmp/meta.txt",
     )
     argv = plan.run_argv()
-    # The mount targets are *relative* to the box root.  isolate
-    # refuses to create subdirectories in bound directories, so
-    # absolute paths like ``/box/submission`` would double-up the
-    # prefix and fail at mount time with ``Cannot mount ... on
-    # box/submission: Permission denied``.  Inside the sandbox the
-    # mounts still appear at ``/box/submission`` and ``/box/grader``
-    # because isolate exposes the box root at ``/box``.
+    # ``isolate --dir`` target paths are interpreted relative to the
+    # sandbox root (isolate strips the leading ``/``).  We mount the
+    # host submission and grader at ``/submission`` and ``/grader``
+    # in the sandbox -- not under ``/box``, because isolate refuses
+    # to create subdirectories in already-bound directories and
+    # ``/box`` is a default bind-mount.
     assert f"submission={tmp_path}:rw" in argv
     assert "grader=/path/to/grader" in argv
     # Sanity: confirm we did NOT regress to the old absolute-path form.
     assert f"/box/submission={tmp_path}:rw" not in argv
     assert "/box/grader=/path/to/grader" not in argv
+    assert f"/submission={tmp_path}:rw" not in argv
+    assert "/grader=/path/to/grader" not in argv
 
 
 def test_run_argv_sets_environment(tmp_path):
@@ -170,9 +171,11 @@ def test_run_argv_sets_environment(tmp_path):
         meta_path="/tmp/meta.txt",
     )
     argv = plan.run_argv()
-    assert "PYTHONPATH=/box/grader" in argv
+    # Env vars point at the sandbox-root mount paths; see
+    # ``test_run_argv_includes_required_bind_mounts``.
+    assert "PYTHONPATH=/grader" in argv
     assert "MPLBACKEND=Agg" in argv
-    assert "HOME=/box/submission" in argv
+    assert "HOME=/submission" in argv
 
 
 def test_run_argv_does_not_enable_network(tmp_path):
@@ -195,8 +198,40 @@ def test_run_argv_appends_extra_dirs(tmp_path):
         extra_dirs=[("etc", "/etc", ""), ("opt", "/opt/cache", "rw")],
     )
     argv = plan.run_argv()
-    assert "/box/etc=/etc" in argv
-    assert "/box/opt=/opt/cache:rw" in argv
+    # Mount targets are relative to the sandbox root (same as the
+    # ``submission`` / ``grader`` mounts above).  Inside the sandbox
+    # they appear at ``/etc`` and ``/opt``.
+    assert "etc=/etc" in argv
+    assert "opt=/opt/cache:rw" in argv
+    # Guard against regressing to the old absolute-path form.
+    assert "/box/etc=/etc" not in argv
+    assert "/box/opt=/opt/cache:rw" not in argv
+
+
+def test_run_argv_chdir_points_at_sandbox_submission(tmp_path):
+    """``--chdir`` must point at the in-sandbox submission mount.
+
+    isolate's chroot root is the sandbox root, *not* ``/box``.  The
+    submission is bind-mounted at ``/submission`` (because isolate
+    will not mount inside the default ``/box`` bind-mount), so the
+    worker's cwd must also be ``/submission``.  Passing
+    ``/box/submission`` -- or the relative ``submission`` -- causes
+    isolate to fail with ``chdir: No such file or directory`` because
+    the default cwd at chdir time is ``/box`` and ``box/submission``
+    does not exist.
+    """
+    plan = build_run_plan(
+        _request(str(tmp_path)),
+        box_id=0,
+        grader_src="/g",
+        meta_path="/tmp/meta.txt",
+    )
+    argv = plan.run_argv()
+    chdir_idx = argv.index("--chdir")
+    assert argv[chdir_idx + 1] == "/submission"
+    # Guard against regressing to either of the previous broken forms.
+    assert argv[chdir_idx + 1] != "/box/submission"
+    assert argv[chdir_idx + 1] != "submission"
 
 
 def test_run_argv_runs_worker_main_module(tmp_path):
@@ -215,6 +250,15 @@ def test_run_argv_runs_worker_main_module(tmp_path):
     assert tail[0] == "/usr/bin/python3"
     assert tail[-1] == "generic_grader.sandbox.worker_main"
     assert "-m" in tail
+    # The worker relies on ``PYTHONPATH=/grader`` to locate the
+    # generic_grader package.  ``-I`` (isolated mode) implies ``-E``
+    # which makes Python ignore ``PYTHONPATH`` -- so we must not pass
+    # ``-I``.  We still want ``-S``/``-s``/``-P`` for partial
+    # isolation.  See the long comment in ``runner.py`` for details.
+    assert "-I" not in tail
+    assert "-S" in tail
+    assert "-s" in tail
+    assert "-P" in tail
 
 
 # ---------------------------------------------------------------------------
@@ -392,7 +436,7 @@ def test_runner_writes_request_frame_to_worker_stdin(tmp_path):
 
 
 def test_runner_rewrites_submission_dir_in_frame_to_sandbox_path(tmp_path):
-    """The host's ``submission_dir`` is rewritten to ``/box/submission``
+    """The host's ``submission_dir`` is rewritten to ``/submission``
     before being serialized to the worker.  The host path is unreachable
     inside the sandbox -- only the bind-mounted path exists -- so the
     worker must receive the in-sandbox path or its ``os.chdir`` will
@@ -413,7 +457,7 @@ def test_runner_rewrites_submission_dir_in_frame_to_sandbox_path(tmp_path):
     newline_index = stdin_bytes.index(b"\n")
     payload = stdin_bytes[newline_index + 1 :].decode("utf-8")
     frame = json.loads(payload)
-    assert frame["submission_dir"] == "/box/submission"
+    assert frame["submission_dir"] == "/submission"
     # The original request must not have been mutated -- the host-side
     # caller may still inspect it (e.g. for logging).
     assert request.submission_dir == host_path
@@ -757,7 +801,8 @@ def _isolate_can_bind_mount() -> bool:  # pragma: no cover - env probe
                 [
                     REAL_ISOLATE,
                     "--box-id=99",
-                    f"--dir=/box/probe={probe}",
+                    # Mount target is relative to the box root.
+                    f"--dir=probe={probe}",
                     "--run",
                     "--",
                     "/bin/true",

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -36,7 +36,7 @@ from generic_grader.sandbox.protocol import (
 )
 from generic_grader.sandbox.runner import (
     IsolateRunner,
-    _python_prefix_mount,
+    _python_prefix_mounts,
     build_run_plan,
     classify_meta,
     parse_meta,
@@ -212,13 +212,40 @@ def test_run_argv_appends_extra_dirs(tmp_path):
     assert "/box/opt=/opt/cache:rw" not in argv
 
 
-def test_python_prefix_mount_skips_default_roots():
+def test_python_prefix_mounts_skips_default_roots():
     """Pythons already inside isolate's default mounts need no extra ``--dir``."""
     for path in ("/usr/bin/python3", "/usr/local/bin/python3", "/bin/python"):
-        assert _python_prefix_mount(path) is None, path
+        assert _python_prefix_mounts(path) == [], path
 
 
-def test_python_prefix_mount_exposes_non_default_python(tmp_path):
+def test_python_prefix_mounts_does_not_follow_symlinks(monkeypatch, tmp_path):
+    """The literal argv path must be visible in the chroot, not its target.
+
+    A venv ``bin/python`` is a symlink to a base interpreter that
+    often lives under ``/usr``.  Resolving the symlink *before*
+    checking against default mounts would make us decide ``no mount
+    needed`` -- but the chroot still can't ``execve`` the literal
+    venv path because the venv directory itself is not mounted.
+    This regression hit the Gradescope grader, whose ``/env`` venv
+    symlinks to ``/usr/bin/python3.13``.
+    """
+    venv = tmp_path / "env"
+    (venv / "bin").mkdir(parents=True)
+    # The venv ``python`` is a symlink to a system python under /usr.
+    venv_exe = venv / "bin" / "python3.13"
+    venv_exe.symlink_to("/usr/bin/python3.13")
+    # Pretend the running interpreter *is* the venv.
+    monkeypatch.setattr(sys, "executable", str(venv_exe))
+    monkeypatch.setattr(sys, "prefix", str(venv))
+    monkeypatch.setattr(sys, "base_prefix", "/usr")
+
+    mounts = _python_prefix_mounts(str(venv_exe))
+    # The venv directory must be exposed even though the symlink
+    # target lives under ``/usr`` (a default mount).
+    assert (str(venv).lstrip("/"), str(venv), "") in mounts
+
+
+def test_python_prefix_mounts_exposes_non_default_python(tmp_path):
     """A python under ``$HOME`` (e.g. uv, pyenv, venv) gets bind-mounted.
 
     The mount target equals the source path (with the leading ``/``
@@ -236,9 +263,9 @@ def test_python_prefix_mount_exposes_non_default_python(tmp_path):
     fake_exe.write_text("#!/bin/sh\necho hi\n")
     fake_exe.chmod(0o755)
 
-    mount = _python_prefix_mount(str(fake_exe))
-    assert mount is not None
-    target, source, opts = mount
+    mounts = _python_prefix_mounts(str(fake_exe))
+    assert len(mounts) == 1
+    target, source, opts = mounts[0]
     # Target is the source path minus the leading slash.
     assert source == str(fake_prefix)
     assert target == str(fake_prefix).lstrip("/")
@@ -247,32 +274,49 @@ def test_python_prefix_mount_exposes_non_default_python(tmp_path):
     assert opts == ""
 
 
-def test_python_prefix_mount_uses_base_prefix_for_running_interpreter(
+def test_python_prefix_mounts_uses_sys_prefix_for_running_interpreter(
     monkeypatch, tmp_path
 ):
-    """When ``python_exe == sys.executable``, use ``sys.base_prefix``.
+    """When ``python_exe == sys.executable``, use ``sys.prefix``."""
+    venv = tmp_path / "my-venv"
+    (venv / "bin").mkdir(parents=True)
+    venv_exe = venv / "bin" / "python3"
+    venv_exe.write_text("#!/bin/sh\n")
+    venv_exe.chmod(0o755)
+    monkeypatch.setattr(sys, "executable", str(venv_exe))
+    monkeypatch.setattr(sys, "prefix", str(venv))
+    # Base prefix is under /usr -- already a default mount, so it
+    # should NOT produce a second mount entry.
+    monkeypatch.setattr(sys, "base_prefix", "/usr")
 
-    ``sys.base_prefix`` is the right answer for venvs (where
-    ``sys.prefix`` points at the venv but the actual interpreter
-    binary and stdlib live under ``base_prefix``).  This branch is
-    only taken when the caller asks us to run the *current*
-    interpreter; for any other path we fall back to ``../..``.
+    mounts = _python_prefix_mounts(str(venv_exe))
+    assert mounts == [(str(venv).lstrip("/"), str(venv), "")]
+
+
+def test_python_prefix_mounts_includes_base_prefix_when_outside_defaults(
+    monkeypatch, tmp_path
+):
+    """A uv-managed base interpreter outside ``/usr`` is also mounted.
+
+    When the venv's symlinked-to base prefix (``sys.base_prefix``)
+    lives outside isolate's default mounts -- as it does for uv,
+    pyenv, and conda managed pythons -- the chroot needs to see
+    *both* the venv prefix (for the ``bin/python`` entry argv points
+    at) and the base prefix (for ``libpython*.so`` and the stdlib).
     """
-    fake_prefix = tmp_path / "current-python"
-    (fake_prefix / "bin").mkdir(parents=True)
-    fake_exe = fake_prefix / "bin" / "python3"
-    fake_exe.write_text("#!/bin/sh\n")
-    fake_exe.chmod(0o755)
-    # Pretend the test runner *is* this fake interpreter.
-    monkeypatch.setattr(sys, "executable", str(fake_exe))
-    # And that its base_prefix is the directory we expect to mount.
-    monkeypatch.setattr(sys, "base_prefix", str(fake_prefix))
+    venv = tmp_path / "venv"
+    base = tmp_path / "uv-cpython-3.12"
+    (venv / "bin").mkdir(parents=True)
+    (base / "bin").mkdir(parents=True)
+    venv_exe = venv / "bin" / "python3"
+    venv_exe.symlink_to(base / "bin" / "python3")
+    monkeypatch.setattr(sys, "executable", str(venv_exe))
+    monkeypatch.setattr(sys, "prefix", str(venv))
+    monkeypatch.setattr(sys, "base_prefix", str(base))
 
-    mount = _python_prefix_mount(str(fake_exe))
-    assert mount is not None
-    target, source, _opts = mount
-    assert source == str(fake_prefix)
-    assert target == str(fake_prefix).lstrip("/")
+    mounts = _python_prefix_mounts(str(venv_exe))
+    assert (str(venv).lstrip("/"), str(venv), "") in mounts
+    assert (str(base).lstrip("/"), str(base), "") in mounts
 
 
 def test_build_run_plan_auto_mounts_external_python(tmp_path):

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -20,6 +20,7 @@ import io
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -598,6 +599,26 @@ def test_worker_main_reports_malformed_request_frame():
     assert response.exception[0]["type"] == "SandboxProtocolError"
 
 
+def test_worker_main_reports_clean_eof_as_protocol_error():
+    """An EOF on stdin (no frame at all) must not crash the worker.
+
+    Regression: previously `run_request(None)` raised `AttributeError`.
+    Now the worker emits a structured `SandboxProtocolError` response.
+    """
+    from generic_grader.sandbox.protocol import read_response
+    from generic_grader.sandbox.worker_main import main
+
+    stdin = io.BytesIO(b"")
+    stdout = io.BytesIO()
+    code = main(stdin=stdin, stdout=stdout)
+    assert code == 2
+    stdout.seek(0)
+    response = read_response(stdout)
+    assert response.exception is not None
+    assert response.exception[0]["type"] == "SandboxProtocolError"
+    assert "no request" in response.exception[0]["message"].lower()
+
+
 # ---------------------------------------------------------------------------
 # Default subprocess runner & misc helpers
 # ---------------------------------------------------------------------------
@@ -627,6 +648,31 @@ def test_meta_time_returns_zero_when_values_unparseable(tmp_path):
     runner = _make_runner(fake)
     resp = runner.run(_request(str(tmp_path)))
     assert resp.elapsed_seconds == 0.0
+
+
+def test_run_rejects_worker_stdout_exceeding_cap(tmp_path):
+    """A runaway worker that spews bytes is rejected, not buffered.
+
+    Without a cap, `subprocess.run(capture_output=True)` would buffer
+    the child's entire stdout into host memory.  The runner enforces
+    a hard ceiling so an outsized payload becomes an actionable
+    SandboxException instead of an OOM.
+    """
+    fake = FakeIsolate(
+        run_stdout=b"x" * 1000,
+        run_returncode=0,
+        meta_text="",
+    )
+    runner = IsolateRunner(
+        grader_src=str(tmp_path / "src"),
+        isolate_binary="/fake/isolate",
+        box_id=1,
+        python_executable=sys.executable,
+        subprocess_runner=fake,
+        max_response_bytes=100,
+    )
+    with pytest.raises(SandboxException, match="exceeded"):
+        runner.run(_request(str(tmp_path)))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -1,0 +1,724 @@
+"""Tests for the isolate-based sandbox runner.
+
+The runner is split so the bulk of the logic is testable without a
+real `isolate` install:
+
+* `build_run_plan` / `RunPlan` are pure: tests assert directly on the
+  argv they produce.
+* `parse_meta` / `classify_meta` are pure string -> dict functions
+  that we exercise with synthetic meta-file contents.
+* `IsolateRunner.run` takes an injectable `subprocess_runner` so we
+  can swap a real subprocess for a deterministic fake.
+
+A separate integration test (skipped when `isolate` is unavailable)
+exercises the real binary; see the bottom of the file.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from generic_grader.sandbox.protocol import (
+    Event,
+    Request,
+    Response,
+    SandboxException,
+    write_response,
+)
+from generic_grader.sandbox.runner import (
+    IsolateRunner,
+    build_run_plan,
+    classify_meta,
+    parse_meta,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-function tests: command construction
+# ---------------------------------------------------------------------------
+
+
+def _request(submission_dir: str, **overrides: Any) -> Request:
+    base = dict(
+        runtime="python",
+        submission_dir=submission_dir,
+        module="submission",
+        obj_name="main",
+    )
+    base.update(overrides)
+    return Request(**base)
+
+
+def test_build_run_plan_uses_request_resource_limits(tmp_path):
+    req = _request(
+        str(tmp_path),
+        time_limit_seconds=5.0,
+        memory_limit_mb=128,
+    )
+    plan = build_run_plan(
+        req,
+        box_id=3,
+        grader_src="/grader/src",
+        meta_path="/tmp/meta.txt",
+        python_executable="/usr/bin/python3",
+    )
+    assert plan.box_id == 3
+    assert plan.submission_dir == str(tmp_path)
+    assert plan.time_limit_seconds == 5.0
+    assert plan.memory_limit_mb == 128
+
+
+def test_build_run_plan_uses_request_defaults_when_limits_unspecified(tmp_path):
+    """Request itself supplies defaults; the plan reflects them verbatim."""
+    req = _request(str(tmp_path))
+    plan = build_run_plan(
+        req,
+        box_id=0,
+        grader_src="/grader/src",
+        meta_path="/tmp/meta.txt",
+    )
+    # Request default is 1.0s / 1400 MB
+    assert plan.time_limit_seconds == 1.0
+    assert plan.memory_limit_mb == 1400
+    # Wall-time is double the CPU time.
+    assert plan.wall_time_limit_seconds == 2.0
+
+
+def test_build_run_plan_uses_sys_executable_when_python_executable_unset(tmp_path):
+    import sys
+
+    req = _request(str(tmp_path))
+    plan = build_run_plan(
+        req,
+        box_id=0,
+        grader_src="/grader/src",
+        meta_path="/tmp/meta.txt",
+    )
+    assert plan.python_executable == sys.executable
+
+
+def test_init_argv_uses_box_id_and_isolate_binary(tmp_path):
+    plan = build_run_plan(
+        _request(str(tmp_path)),
+        box_id=7,
+        grader_src="/grader/src",
+        meta_path="/tmp/meta.txt",
+        isolate_binary="/usr/bin/isolate",
+    )
+    assert plan.init_argv() == ["/usr/bin/isolate", "--box-id", "7", "--init"]
+    assert plan.cleanup_argv() == ["/usr/bin/isolate", "--box-id", "7", "--cleanup"]
+
+
+def test_run_argv_carries_resource_limits(tmp_path):
+    req = _request(
+        str(tmp_path),
+        time_limit_seconds=4.0,
+        memory_limit_mb=64,
+    )
+    plan = build_run_plan(
+        req,
+        box_id=0,
+        grader_src="/grader/src",
+        meta_path="/tmp/meta.txt",
+    )
+    argv = plan.run_argv()
+    assert "--time" in argv
+    assert argv[argv.index("--time") + 1] == "4.000"
+    assert "--wall-time" in argv
+    # memory is in KB inside the argv
+    assert "--mem" in argv
+    assert argv[argv.index("--mem") + 1] == str(64 * 1024)
+
+
+def test_run_argv_includes_required_bind_mounts(tmp_path):
+    req = _request(str(tmp_path))
+    plan = build_run_plan(
+        req,
+        box_id=0,
+        grader_src="/path/to/grader",
+        meta_path="/tmp/meta.txt",
+    )
+    argv = plan.run_argv()
+    # /box/submission is RW and points at the request's submission_dir
+    assert f"/box/submission={tmp_path}:rw" in argv
+    # /box/grader is RO and points at the grader source
+    assert "/box/grader=/path/to/grader" in argv
+
+
+def test_run_argv_sets_environment(tmp_path):
+    req = _request(str(tmp_path))
+    plan = build_run_plan(
+        req,
+        box_id=0,
+        grader_src="/path/to/grader",
+        meta_path="/tmp/meta.txt",
+    )
+    argv = plan.run_argv()
+    assert "PYTHONPATH=/box/grader" in argv
+    assert "MPLBACKEND=Agg" in argv
+    assert "HOME=/box/submission" in argv
+
+
+def test_run_argv_does_not_enable_network(tmp_path):
+    """The runner relies on isolate's default of network isolation."""
+    plan = build_run_plan(
+        _request(str(tmp_path)),
+        box_id=0,
+        grader_src="/g",
+        meta_path="/tmp/meta.txt",
+    )
+    assert "--share-net" not in plan.run_argv()
+
+
+def test_run_argv_appends_extra_dirs(tmp_path):
+    plan = build_run_plan(
+        _request(str(tmp_path)),
+        box_id=0,
+        grader_src="/g",
+        meta_path="/tmp/meta.txt",
+        extra_dirs=[("etc", "/etc", ""), ("opt", "/opt/cache", "rw")],
+    )
+    argv = plan.run_argv()
+    assert "/box/etc=/etc" in argv
+    assert "/box/opt=/opt/cache:rw" in argv
+
+
+def test_run_argv_runs_worker_main_module(tmp_path):
+    """Argv ends with `-m generic_grader.sandbox.worker_main`."""
+    plan = build_run_plan(
+        _request(str(tmp_path)),
+        box_id=0,
+        grader_src="/g",
+        meta_path="/tmp/meta.txt",
+        python_executable="/usr/bin/python3",
+    )
+    argv = plan.run_argv()
+    assert "--run" in argv
+    assert "--" in argv
+    tail = argv[argv.index("--") + 1 :]
+    assert tail[0] == "/usr/bin/python3"
+    assert tail[-1] == "generic_grader.sandbox.worker_main"
+    assert "-m" in tail
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests: meta parsing & classification
+# ---------------------------------------------------------------------------
+
+
+def test_parse_meta_extracts_known_keys():
+    meta = parse_meta("time:1.234\nstatus:TO\nmessage:Timed out\n")
+    assert meta == {"time": "1.234", "status": "TO", "message": "Timed out"}
+
+
+def test_parse_meta_ignores_blank_and_malformed_lines():
+    meta = parse_meta("time:1.0\n\n\nthisisnotvalid\nexitcode:0\n")
+    assert meta == {"time": "1.0", "exitcode": "0"}
+
+
+def test_classify_meta_clean_run_returns_none():
+    assert classify_meta({"time": "0.1", "exitcode": "0"}) is None
+
+
+def test_classify_meta_clean_run_with_no_keys_returns_none():
+    assert classify_meta({}) is None
+
+
+def test_classify_meta_timeout_maps_to_sandbox_timeout():
+    out = classify_meta({"status": "TO", "message": "limit"})
+    assert out["type"] == "SandboxTimeout"
+    assert "limit" in out["message"]
+
+
+def test_classify_meta_memory_limit_maps_to_sandbox_memory_limit():
+    out = classify_meta({"status": "ML"})
+    assert out["type"] == "SandboxMemoryLimit"
+
+
+def test_classify_meta_signal_maps_to_sandbox_signal():
+    out = classify_meta({"status": "SG", "exitsig": "9"})
+    assert out["type"] == "SandboxSignal"
+    assert "9" in out["message"]
+
+
+def test_classify_meta_internal_error_maps_to_sandbox_internal_error():
+    out = classify_meta({"status": "XX", "message": "boom"})
+    assert out["type"] == "SandboxInternalError"
+    assert "boom" in out["message"]
+
+
+def test_classify_meta_unknown_status_maps_to_abnormal_exit():
+    out = classify_meta({"status": "RE", "exitcode": "1"})
+    assert out["type"] == "SandboxAbnormalExit"
+
+
+def test_classify_meta_no_status_but_nonzero_exitcode_maps_to_abnormal_exit():
+    out = classify_meta({"exitcode": "2"})
+    assert out["type"] == "SandboxAbnormalExit"
+
+
+# ---------------------------------------------------------------------------
+# IsolateRunner.run() with injected subprocess
+# ---------------------------------------------------------------------------
+
+
+class FakeIsolate:
+    """A stand-in for the isolate binary that records calls and returns canned data.
+
+    Wired into `IsolateRunner` via `subprocess_runner=`. Each call
+    appends a (argv, stdin_bytes) tuple to `calls` and dispatches
+    based on the subcommand at argv position 3 (init / cleanup / run).
+    """
+
+    def __init__(
+        self,
+        *,
+        run_stdout: bytes = b"",
+        run_stderr: bytes = b"",
+        run_returncode: int = 0,
+        meta_text: str = "time:0.05\nexitcode:0\n",
+        init_returncode: int = 0,
+        init_stderr: str = "",
+    ) -> None:
+        self.run_stdout = run_stdout
+        self.run_stderr = run_stderr
+        self.run_returncode = run_returncode
+        self.meta_text = meta_text
+        self.init_returncode = init_returncode
+        self.init_stderr = init_stderr
+        self.calls: list[tuple[list[str], bytes | None]] = []
+
+    def __call__(self, argv, **kwargs):
+        # Always record the call for assertions.
+        self.calls.append((list(argv), kwargs.get("input")))
+
+        if "--init" in argv:
+            return subprocess.CompletedProcess(
+                argv, self.init_returncode, "", self.init_stderr
+            )
+        if "--cleanup" in argv:
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        # --run path: write meta to the path given by --meta and return
+        # the canned stdout/stderr.
+        meta_path = argv[argv.index("--meta") + 1]
+        Path(meta_path).write_text(self.meta_text)
+        return subprocess.CompletedProcess(
+            argv,
+            self.run_returncode,
+            self.run_stdout,
+            self.run_stderr,
+        )
+
+
+def _make_runner(
+    fake: FakeIsolate, *, isolate_binary: str = "/fake/isolate"
+) -> IsolateRunner:
+    return IsolateRunner(
+        grader_src="/grader/src",
+        isolate_binary=isolate_binary,
+        box_id=0,
+        subprocess_runner=fake,
+    )
+
+
+def _make_response_bytes(
+    events: tuple[Event, ...] = (),
+    exception=None,
+    elapsed: float = 0.5,
+) -> bytes:
+    buf = io.BytesIO()
+    write_response(
+        buf,
+        Response(events=list(events), exception=exception, elapsed_seconds=elapsed),
+    )
+    return buf.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def _patch_which(monkeypatch: pytest.MonkeyPatch):
+    """Make `shutil.which` claim the fake isolate is on PATH."""
+    monkeypatch.setattr(
+        "generic_grader.sandbox.runner.shutil.which",
+        lambda cmd: cmd if cmd == "/fake/isolate" else None,
+    )
+
+
+def test_runner_invokes_init_run_cleanup_in_order(tmp_path):
+    """Each run goes through init -> run -> cleanup."""
+    fake = FakeIsolate(
+        run_stdout=_make_response_bytes(events=(Event(type="return", value=42),)),
+    )
+    runner = _make_runner(fake)
+    runner.run(_request(str(tmp_path)))
+    subcommands = []
+    for argv, _stdin in fake.calls:
+        for flag in ("--init", "--run", "--cleanup"):
+            if flag in argv:
+                subcommands.append(flag)
+    assert subcommands == ["--init", "--run", "--cleanup"]
+
+
+def test_runner_writes_request_frame_to_worker_stdin(tmp_path):
+    fake = FakeIsolate(
+        run_stdout=_make_response_bytes(events=(Event(type="return", value=1),)),
+    )
+    runner = _make_runner(fake)
+    runner.run(_request(str(tmp_path)))
+    run_calls = [c for c in fake.calls if "--run" in c[0]]
+    assert len(run_calls) == 1
+    stdin_bytes = run_calls[0][1]
+    assert stdin_bytes is not None
+    # Frame format: <decimal length>\n<json>
+    newline_index = stdin_bytes.index(b"\n")
+    length = int(stdin_bytes[:newline_index])
+    payload = stdin_bytes[newline_index + 1 :]
+    assert len(payload) == length
+
+
+def test_runner_returns_decoded_response_when_worker_succeeds(tmp_path):
+    fake = FakeIsolate(
+        run_stdout=_make_response_bytes(
+            events=(Event(type="return", value=7),),
+            elapsed=0.123,
+        ),
+    )
+    runner = _make_runner(fake)
+    resp = runner.run(_request(str(tmp_path)))
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value == 7
+    assert resp.exception is None
+
+
+def test_runner_synthesizes_timeout_response_when_worker_killed(tmp_path):
+    fake = FakeIsolate(
+        run_stdout=b"",
+        run_returncode=124,
+        meta_text="status:TO\ntime:1.99\nmessage:Time limit exceeded\n",
+    )
+    runner = _make_runner(fake)
+    resp = runner.run(_request(str(tmp_path), time_limit_seconds=1.0))
+    assert resp.exception is not None
+    assert resp.exception[0]["type"] == "SandboxTimeout"
+    # The elapsed time should be picked up from the meta file.
+    assert resp.elapsed_seconds == pytest.approx(1.99, rel=1e-3)
+
+
+def test_runner_synthesizes_memory_response_when_worker_oom(tmp_path):
+    fake = FakeIsolate(
+        run_stdout=b"",
+        run_returncode=137,
+        meta_text="status:ML\ntime:0.10\n",
+    )
+    runner = _make_runner(fake)
+    resp = runner.run(_request(str(tmp_path)))
+    assert resp.exception[0]["type"] == "SandboxMemoryLimit"
+
+
+def test_runner_synthesizes_generic_failure_when_no_meta_and_no_frame(tmp_path):
+    fake = FakeIsolate(
+        run_stdout=b"",
+        run_stderr=b"ImportError: no module named 'foo'\n",
+        run_returncode=1,
+        meta_text="",
+    )
+    runner = _make_runner(fake)
+    resp = runner.run(_request(str(tmp_path)))
+    assert resp.exception[0]["type"] == "SandboxAbnormalExit"
+    # The student-visible message should include stderr so the
+    # underlying Python complaint is reachable.
+    assert "ImportError" in resp.exception[0]["message"]
+
+
+def test_runner_recovers_when_meta_file_unreadable(tmp_path, monkeypatch):
+    fake = FakeIsolate(
+        run_stdout=b"",
+        run_returncode=1,
+        meta_text="",  # the FakeIsolate writes an empty meta file
+    )
+
+    # Force the meta file open to raise so we exercise the OSError path.
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        if "isolate-meta-" in str(path):
+            raise OSError("permission denied")
+        return real_open(path, *args, **kwargs)  # pragma: no cover
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    runner = _make_runner(fake)
+    resp = runner.run(_request(str(tmp_path)))
+    # The runner still produces a SandboxAbnormalExit response.
+    assert resp.exception[0]["type"] == "SandboxAbnormalExit"
+
+
+def test_runner_returns_worker_frame_even_when_meta_classifies_abnormal(tmp_path):
+    """When both a frame and a non-zero meta exist, the frame wins.
+
+    Rationale: the worker successfully reported its own result, so
+    the meta-level diagnostics are redundant. (The frame may itself
+    carry the relevant exception.)
+    """
+    payload = _make_response_bytes(events=(Event(type="return", value=1),))
+    fake = FakeIsolate(
+        run_stdout=payload,
+        run_returncode=0,
+        meta_text="status:RE\nexitcode:1\n",
+    )
+    runner = _make_runner(fake)
+    resp = runner.run(_request(str(tmp_path)))
+    returns = [e for e in resp.events if e.type == "return"]
+    assert returns[0].value == 1
+
+
+def test_runner_partial_frame_falls_back_to_meta_classification(tmp_path):
+    fake = FakeIsolate(
+        run_stdout=b"99\nNOT_REALLY_A_JSON_FRAME",
+        run_returncode=1,
+        meta_text="status:TO\ntime:0.5\n",
+    )
+    runner = _make_runner(fake)
+    resp = runner.run(_request(str(tmp_path)))
+    assert resp.exception[0]["type"] == "SandboxTimeout"
+
+
+def test_runner_raises_when_isolate_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "generic_grader.sandbox.runner.shutil.which",
+        lambda cmd: None,
+    )
+    runner = IsolateRunner(
+        grader_src="/g",
+        isolate_binary="not-installed",
+        subprocess_runner=lambda *a, **k: pytest.fail("should not be called"),
+    )
+    with pytest.raises(SandboxException) as exc:
+        runner.run(_request(str(tmp_path)))
+    assert "isolate" in str(exc.value).lower()
+
+
+def test_runner_raises_when_init_fails(tmp_path):
+    fake = FakeIsolate(
+        init_returncode=1,
+        init_stderr="box 0 already in use",
+    )
+    runner = _make_runner(fake)
+    with pytest.raises(SandboxException) as exc:
+        runner.run(_request(str(tmp_path)))
+    assert "box 0 already in use" in str(exc.value)
+
+
+def test_runner_cleans_up_meta_file_after_run(tmp_path):
+    """Meta files live in tempdir; the runner must delete them on the way out."""
+    fake = FakeIsolate(
+        run_stdout=_make_response_bytes(events=(Event(type="return", value=1),)),
+    )
+    runner = _make_runner(fake)
+
+    # Snapshot meta files before; they live in the system tempdir with
+    # a recognizable prefix.
+    import tempfile
+
+    tmp_root = Path(tempfile.gettempdir())
+    before = set(tmp_root.glob("isolate-meta-*"))
+    runner.run(_request(str(tmp_path)))
+    after = set(tmp_root.glob("isolate-meta-*"))
+    assert before == after
+
+
+def test_runner_runs_cleanup_even_when_worker_failed(tmp_path):
+    """Cleanup must happen on every run, even when --run returned nonzero."""
+    fake = FakeIsolate(
+        run_stdout=b"",
+        run_returncode=1,
+        meta_text="status:RE\nexitcode:1\n",
+    )
+    runner = _make_runner(fake)
+    runner.run(_request(str(tmp_path)))
+    cleanup_calls = [c for c in fake.calls if "--cleanup" in c[0]]
+    assert len(cleanup_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# worker_main entry point
+# ---------------------------------------------------------------------------
+
+
+def test_worker_main_round_trips_request(tmp_path):
+    """worker_main should consume a framed request and produce a framed response."""
+    import textwrap
+
+    from generic_grader.sandbox.protocol import read_response, write_request
+    from generic_grader.sandbox.worker_main import main
+
+    (tmp_path / "submission.py").write_text(
+        textwrap.dedent(
+            """
+            def main():
+                return "ok"
+            """
+        )
+    )
+    request = Request(
+        runtime="python",
+        submission_dir=str(tmp_path),
+        module="submission",
+        obj_name="main",
+    )
+    stdin = io.BytesIO()
+    write_request(stdin, request)
+    stdin.seek(0)
+    stdout = io.BytesIO()
+    code = main(stdin=stdin, stdout=stdout)
+    assert code == 0
+    stdout.seek(0)
+    response = read_response(stdout)
+    returns = [e for e in response.events if e.type == "return"]
+    assert returns[0].value == "ok"
+
+
+def test_worker_main_reports_malformed_request_frame():
+    """A malformed input frame produces a SandboxProtocolError response."""
+    from generic_grader.sandbox.protocol import read_response
+    from generic_grader.sandbox.worker_main import main
+
+    stdin = io.BytesIO(b"NOT_A_LENGTH_PREFIX")
+    stdout = io.BytesIO()
+    code = main(stdin=stdin, stdout=stdout)
+    assert code == 2
+    stdout.seek(0)
+    response = read_response(stdout)
+    assert response.exception is not None
+    assert response.exception[0]["type"] == "SandboxProtocolError"
+
+
+# ---------------------------------------------------------------------------
+# Default subprocess runner & misc helpers
+# ---------------------------------------------------------------------------
+
+
+def test_default_subprocess_runner_runs_real_subprocess():
+    """The default runner is just `subprocess.run`."""
+    from generic_grader.sandbox.runner import _default_subprocess_runner
+
+    out = _default_subprocess_runner(
+        ["python", "-c", "print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert out.returncode == 0
+    assert "ok" in out.stdout
+
+
+def test_meta_time_returns_zero_when_values_unparseable(tmp_path):
+    """Garbage in time / time-wall should not crash the runner."""
+    fake = FakeIsolate(
+        run_stdout=b"",
+        run_returncode=1,
+        meta_text="time:not-a-number\ntime-wall:also-bad\n",
+    )
+    runner = _make_runner(fake)
+    resp = runner.run(_request(str(tmp_path)))
+    assert resp.elapsed_seconds == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Optional real-isolate integration test
+# ---------------------------------------------------------------------------
+
+
+_ORIGINAL_SHUTIL_WHICH = shutil.which
+REAL_ISOLATE = _ORIGINAL_SHUTIL_WHICH("isolate")
+
+
+def _isolate_can_bind_mount() -> bool:  # pragma: no cover - env probe
+    """Probe whether nested bind mounts are permitted in this environment.
+
+    Containerized CI/dev environments often disallow the bind mounts that
+    `isolate` relies on; in those environments the smoke test can't run
+    even when the binary itself is installed.
+    """
+    if REAL_ISOLATE is None:
+        return False
+    probe = tempfile.mkdtemp(prefix="isolate-probe-")
+    try:
+        os.chmod(probe, 0o755)
+        # Use a unique box id we don't expect anything else to be using.
+        subprocess.run(
+            [REAL_ISOLATE, "--box-id=99", "--cleanup"],
+            capture_output=True,
+            check=False,
+        )
+        init = subprocess.run(
+            [REAL_ISOLATE, "--box-id=99", "--init"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if init.returncode != 0:
+            return False
+        try:
+            result = subprocess.run(
+                [
+                    REAL_ISOLATE,
+                    "--box-id=99",
+                    f"--dir=/box/probe={probe}",
+                    "--run",
+                    "--",
+                    "/bin/true",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            return result.returncode == 0
+        finally:
+            subprocess.run(
+                [REAL_ISOLATE, "--box-id=99", "--cleanup"],
+                capture_output=True,
+                check=False,
+            )
+    finally:
+        shutil.rmtree(probe, ignore_errors=True)
+
+
+_REAL_ISOLATE_USABLE = _isolate_can_bind_mount()
+
+
+@pytest.mark.skipif(
+    not _REAL_ISOLATE_USABLE,
+    reason=(
+        "The `isolate` binary isn't installed, or the kernel disallows the "
+        "nested bind mounts isolate uses (common in nested containers)."
+    ),
+)
+def test_real_isolate_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+):  # pragma: no cover - environment-dependent
+    """End-to-end run against the real isolate binary."""
+    # Undo the autouse `_patch_which` fixture so the real binary is found.
+    monkeypatch.setattr(
+        "generic_grader.sandbox.runner.shutil.which", _ORIGINAL_SHUTIL_WHICH
+    )
+    # isolate's sandbox UID needs to traverse the submission and grader
+    # paths, so use a world-traversable directory rather than the default
+    # `tmp_path` (which lives under a 0700 `/tmp/pytest-of-<user>` tree).
+    sub_dir = tempfile.mkdtemp(prefix="isolate-smoke-sub-")
+    os.chmod(sub_dir, 0o755)
+    try:
+        (Path(sub_dir) / "submission.py").write_text("def main():\n    return 42\n")
+        grader_src = Path(__file__).resolve().parents[2] / "src"
+        runner = IsolateRunner(grader_src=str(grader_src), box_id=0)
+        resp = runner.run(_request(sub_dir))
+        assert resp.exception is None, resp.exception
+        returns = [e for e in resp.events if e.type == "return"]
+        assert returns and returns[0].value == 42
+    finally:
+        shutil.rmtree(sub_dir, ignore_errors=True)

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -35,6 +35,7 @@ from generic_grader.sandbox.protocol import (
     write_response,
 )
 from generic_grader.sandbox.runner import (
+    STARTUP_OVERHEAD_SECONDS,
     IsolateRunner,
     _python_prefix_mounts,
     build_run_plan,
@@ -73,12 +74,15 @@ def test_build_run_plan_uses_request_resource_limits(tmp_path):
     )
     assert plan.box_id == 3
     assert plan.submission_dir == str(tmp_path)
-    assert plan.time_limit_seconds == 5.0
+    # ``Request.time_limit_seconds`` is the student-code budget; the
+    # plan adds ``STARTUP_OVERHEAD_SECONDS`` for interpreter startup
+    # and grader-side imports before handing the number to isolate.
+    assert plan.time_limit_seconds == 5.0 + STARTUP_OVERHEAD_SECONDS
     assert plan.memory_limit_mb == 128
 
 
 def test_build_run_plan_uses_request_defaults_when_limits_unspecified(tmp_path):
-    """Request itself supplies defaults; the plan reflects them verbatim."""
+    """Request itself supplies defaults; the plan adds the startup overhead."""
     req = _request(str(tmp_path))
     plan = build_run_plan(
         req,
@@ -86,11 +90,34 @@ def test_build_run_plan_uses_request_defaults_when_limits_unspecified(tmp_path):
         grader_src="/grader/src",
         meta_path="/tmp/meta.txt",
     )
-    # Request default is 1.0s / 1400 MB
-    assert plan.time_limit_seconds == 1.0
+    # Request default is 1.0s student-code budget / 1400 MB.  The
+    # plan adds ``STARTUP_OVERHEAD_SECONDS`` on top for the CPU limit
+    # that goes to isolate.
+    expected_cpu = 1.0 + STARTUP_OVERHEAD_SECONDS
+    assert plan.time_limit_seconds == expected_cpu
     assert plan.memory_limit_mb == 1400
     # Wall-time is double the CPU time.
-    assert plan.wall_time_limit_seconds == 2.0
+    assert plan.wall_time_limit_seconds == expected_cpu * 2.0
+
+
+def test_startup_overhead_is_positive_and_added_on_top_of_student_budget(tmp_path):
+    """Regression: legacy ``Options.time_limit`` budgeted only the
+    student's code (SIGALRM-wrapped call); isolate's ``--time`` counts
+    CPU for the whole subprocess.  The runner must add a fixed
+    allowance so a trivial ``time_limit=1`` test isn't killed during
+    interpreter startup / grader imports on slower hosts.
+    """
+    assert STARTUP_OVERHEAD_SECONDS > 0
+    req = _request(str(tmp_path), time_limit_seconds=1.0)
+    plan = build_run_plan(
+        req,
+        box_id=0,
+        grader_src="/grader/src",
+        meta_path="/tmp/meta.txt",
+    )
+    # CPU limit handed to isolate strictly exceeds the student budget.
+    assert plan.time_limit_seconds > req.time_limit_seconds
+    assert plan.time_limit_seconds == req.time_limit_seconds + STARTUP_OVERHEAD_SECONDS
 
 
 def test_build_run_plan_uses_sys_executable_when_python_executable_unset(tmp_path):
@@ -132,7 +159,10 @@ def test_run_argv_carries_resource_limits(tmp_path):
     )
     argv = plan.run_argv()
     assert "--time" in argv
-    assert argv[argv.index("--time") + 1] == "4.000"
+    # The argv carries the *isolate* CPU limit, which is the student
+    # budget plus the fixed startup overhead.
+    expected_cpu = 4.0 + STARTUP_OVERHEAD_SECONDS
+    assert argv[argv.index("--time") + 1] == f"{expected_cpu:.3f}"
     assert "--wall-time" in argv
     # memory is in KB inside the argv
     assert "--mem" in argv

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -36,6 +36,7 @@ from generic_grader.sandbox.protocol import (
 )
 from generic_grader.sandbox.runner import (
     IsolateRunner,
+    _python_prefix_mount,
     build_run_plan,
     classify_meta,
     parse_meta,
@@ -195,6 +196,9 @@ def test_run_argv_appends_extra_dirs(tmp_path):
         box_id=0,
         grader_src="/g",
         meta_path="/tmp/meta.txt",
+        # Pin to a default-mount python so the auto-mount logic
+        # doesn't append an extra entry to ``extra_dirs``.
+        python_executable="/usr/bin/python3",
         extra_dirs=[("etc", "/etc", ""), ("opt", "/opt/cache", "rw")],
     )
     argv = plan.run_argv()
@@ -206,6 +210,130 @@ def test_run_argv_appends_extra_dirs(tmp_path):
     # Guard against regressing to the old absolute-path form.
     assert "/box/etc=/etc" not in argv
     assert "/box/opt=/opt/cache:rw" not in argv
+
+
+def test_python_prefix_mount_skips_default_roots():
+    """Pythons already inside isolate's default mounts need no extra ``--dir``."""
+    for path in ("/usr/bin/python3", "/usr/local/bin/python3", "/bin/python"):
+        assert _python_prefix_mount(path) is None, path
+
+
+def test_python_prefix_mount_exposes_non_default_python(tmp_path):
+    """A python under ``$HOME`` (e.g. uv, pyenv, venv) gets bind-mounted.
+
+    The mount target equals the source path (with the leading ``/``
+    stripped, since isolate ``--dir`` targets are relative to the
+    sandbox root).  Mounting at the same absolute path means the
+    argv we already pass to ``--run`` resolves correctly inside the
+    chroot, without any path rewriting.  Without this entry the
+    chroot has no idea where the interpreter binary or its support
+    files live and ``execve`` fails with exit 127.
+    """
+    fake_prefix = tmp_path / "uv-python" / "cpython-3.12.5"
+    (fake_prefix / "bin").mkdir(parents=True)
+    (fake_prefix / "lib").mkdir()
+    fake_exe = fake_prefix / "bin" / "python3.12"
+    fake_exe.write_text("#!/bin/sh\necho hi\n")
+    fake_exe.chmod(0o755)
+
+    mount = _python_prefix_mount(str(fake_exe))
+    assert mount is not None
+    target, source, opts = mount
+    # Target is the source path minus the leading slash.
+    assert source == str(fake_prefix)
+    assert target == str(fake_prefix).lstrip("/")
+    # Read-only (no ``rw`` option): the interpreter directory should
+    # not be writable from inside the sandbox.
+    assert opts == ""
+
+
+def test_python_prefix_mount_uses_base_prefix_for_running_interpreter(
+    monkeypatch, tmp_path
+):
+    """When ``python_exe == sys.executable``, use ``sys.base_prefix``.
+
+    ``sys.base_prefix`` is the right answer for venvs (where
+    ``sys.prefix`` points at the venv but the actual interpreter
+    binary and stdlib live under ``base_prefix``).  This branch is
+    only taken when the caller asks us to run the *current*
+    interpreter; for any other path we fall back to ``../..``.
+    """
+    fake_prefix = tmp_path / "current-python"
+    (fake_prefix / "bin").mkdir(parents=True)
+    fake_exe = fake_prefix / "bin" / "python3"
+    fake_exe.write_text("#!/bin/sh\n")
+    fake_exe.chmod(0o755)
+    # Pretend the test runner *is* this fake interpreter.
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+    # And that its base_prefix is the directory we expect to mount.
+    monkeypatch.setattr(sys, "base_prefix", str(fake_prefix))
+
+    mount = _python_prefix_mount(str(fake_exe))
+    assert mount is not None
+    target, source, _opts = mount
+    assert source == str(fake_prefix)
+    assert target == str(fake_prefix).lstrip("/")
+
+
+def test_build_run_plan_auto_mounts_external_python(tmp_path):
+    """``build_run_plan`` adds the python prefix to ``extra_dirs`` when needed.
+
+    This is the integration point that makes the runtime tests work
+    when the grader is invoked through ``uv`` (or any other tool
+    that puts python outside ``/usr``).  Without it, the worker
+    fails to exec with exit 127.
+    """
+    fake_prefix = tmp_path / "venv"
+    (fake_prefix / "bin").mkdir(parents=True)
+    fake_exe = fake_prefix / "bin" / "python3"
+    fake_exe.write_text("#!/bin/sh\n")
+    fake_exe.chmod(0o755)
+
+    plan = build_run_plan(
+        _request(str(tmp_path)),
+        box_id=0,
+        grader_src="/g",
+        meta_path="/tmp/meta.txt",
+        python_executable=str(fake_exe),
+    )
+    target = str(fake_prefix).lstrip("/")
+    assert (target, str(fake_prefix), "") in plan.extra_dirs
+    # The mount also appears in the run argv.
+    assert f"{target}={fake_prefix}" in plan.run_argv()
+
+
+def test_build_run_plan_skips_python_mount_for_system_python(tmp_path):
+    """A system python under ``/usr/bin`` does not need an extra mount."""
+    plan = build_run_plan(
+        _request(str(tmp_path)),
+        box_id=0,
+        grader_src="/g",
+        meta_path="/tmp/meta.txt",
+        python_executable="/usr/bin/python3",
+    )
+    # No extra mount entries beyond what the caller passed in (none).
+    assert plan.extra_dirs == ()
+
+
+def test_build_run_plan_preserves_explicit_extra_dirs(tmp_path):
+    """User-supplied ``extra_dirs`` are preserved alongside any auto-mount."""
+    fake_prefix = tmp_path / "py"
+    (fake_prefix / "bin").mkdir(parents=True)
+    fake_exe = fake_prefix / "bin" / "python3"
+    fake_exe.write_text("#!/bin/sh\n")
+    fake_exe.chmod(0o755)
+
+    plan = build_run_plan(
+        _request(str(tmp_path)),
+        box_id=0,
+        grader_src="/g",
+        meta_path="/tmp/meta.txt",
+        python_executable=str(fake_exe),
+        extra_dirs=[("custom", "/some/host/dir", "rw")],
+    )
+    # Both the user-supplied and the auto-added mount are present.
+    assert ("custom", "/some/host/dir", "rw") in plan.extra_dirs
+    assert (str(fake_prefix).lstrip("/"), str(fake_prefix), "") in plan.extra_dirs
 
 
 def test_run_argv_chdir_points_at_sandbox_submission(tmp_path):

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -35,9 +35,14 @@ from generic_grader.sandbox.protocol import (
     write_response,
 )
 from generic_grader.sandbox.runner import (
+    PROFILE_ENV_VAR,
     STARTUP_OVERHEAD_SECONDS,
     IsolateRunner,
+    _extract_worker_profile,
+    _meta_profile_subset,
+    _profile_destination,
     _python_prefix_mounts,
+    _write_profile_record,
     build_run_plan,
     classify_meta,
     parse_meta,
@@ -961,6 +966,268 @@ def test_run_rejects_worker_stdout_exceeding_cap(tmp_path):
     )
     with pytest.raises(SandboxException, match="exceeded"):
         runner.run(_request(str(tmp_path)))
+
+
+# ---------------------------------------------------------------------------
+# Profiling instrumentation
+# ---------------------------------------------------------------------------
+
+
+def test_profile_destination_unset_returns_none(monkeypatch: pytest.MonkeyPatch):
+    """Without the env var, profiling is off (no file ever opened)."""
+    monkeypatch.delenv(PROFILE_ENV_VAR, raising=False)
+    assert _profile_destination() is None
+
+
+def test_profile_destination_blank_string_treated_as_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A blank value clears profiling without requiring ``unset``."""
+    monkeypatch.setenv(PROFILE_ENV_VAR, "")
+    assert _profile_destination() is None
+
+
+def test_profile_destination_returns_path_when_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    dest = str(tmp_path / "profile.jsonl")
+    monkeypatch.setenv(PROFILE_ENV_VAR, dest)
+    assert _profile_destination() == dest
+
+
+def test_extract_worker_profile_returns_none_without_event():
+    response = Response(events=[Event(type="return", value=1)], elapsed_seconds=0.5)
+    assert _extract_worker_profile(response) is None
+
+
+def test_extract_worker_profile_returns_checkpoints_when_present():
+    response = Response(
+        events=[
+            Event(type="return", value=1),
+            Event(
+                type="profile",
+                checkpoints=[("enter", 0.0), ("patches_installed", 0.001)],
+            ),
+        ],
+        elapsed_seconds=0.5,
+    )
+    extracted = _extract_worker_profile(response)
+    assert extracted == {
+        "checkpoints": [("enter", 0.0), ("patches_installed", 0.001)],
+        "elapsed_seconds": 0.5,
+    }
+
+
+def test_extract_worker_profile_handles_empty_events_iterable():
+    """`response.events` may be ``None`` for synthesized failure paths."""
+    response = Response(events=[], exception=None, elapsed_seconds=0.0)
+    response.events = None  # type: ignore[assignment]
+    assert _extract_worker_profile(response) is None
+
+
+def test_meta_profile_subset_coerces_numeric_fields():
+    meta = {
+        "time": "0.123",
+        "time-wall": "0.456",
+        "max-rss": "4096",
+        "status": "OK",
+        "exitcode": "0",
+        "ignored": "x",
+    }
+    assert _meta_profile_subset(meta) == {
+        "time": 0.123,
+        "time-wall": 0.456,
+        "max-rss": 4096,
+        "status": "OK",
+        "exitcode": 0,
+    }
+
+
+def test_meta_profile_subset_drops_absent_keys():
+    assert _meta_profile_subset({"time": "0.1"}) == {"time": 0.1}
+
+
+def test_write_profile_record_appends_one_json_line(tmp_path):
+    dest = tmp_path / "profile.jsonl"
+    request = Request(
+        runtime="python",
+        submission_dir="/home/sub",
+        module="submission",
+        obj_name="main",
+    )
+    response = Response(
+        events=[
+            Event(type="return", value=1),
+            Event(
+                type="profile",
+                checkpoints=[("enter", 0.0), ("completed", 0.005)],
+            ),
+        ],
+        elapsed_seconds=0.005,
+    )
+    _write_profile_record(
+        str(dest),
+        request=request,
+        host_timings={
+            "init_seconds": 0.01,
+            "run_seconds": 0.02,
+            "cleanup_seconds": 0.005,
+            "total_seconds": 0.04,
+        },
+        meta_text="time:0.02\nmax-rss:1024\nexitcode:0\n",
+        response=response,
+    )
+    # And again -- the writer is append-only.
+    _write_profile_record(
+        str(dest),
+        request=request,
+        host_timings={"init_seconds": 0.0},
+        meta_text=None,
+        response=None,
+    )
+    lines = dest.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    first = __import__("json").loads(lines[0])
+    assert first["request"] == {
+        "module": "submission",
+        "obj_name": "main",
+        "submission_dir": "/home/sub",
+    }
+    assert first["host"]["run_seconds"] == 0.02
+    assert first["isolate"] == {"time": 0.02, "max-rss": 1024, "exitcode": 0}
+    assert first["worker"]["checkpoints"][0] == ["enter", 0.0]
+    assert first["worker"]["elapsed_seconds"] == 0.005
+    second = __import__("json").loads(lines[1])
+    assert "isolate" not in second
+    assert "worker" not in second
+
+
+def test_write_profile_record_silently_ignores_oserror(tmp_path, monkeypatch):
+    """A broken disk must never escalate into a grader failure."""
+    dest = str(tmp_path / "profile.jsonl")
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    # Patch the builtin ``open`` only inside the runner module so we don't
+    # break the rest of pytest.
+    monkeypatch.setattr("generic_grader.sandbox.runner.open", _boom, raising=False)
+    request = Request(
+        runtime="python",
+        submission_dir="/home/sub",
+        module="submission",
+        obj_name="main",
+    )
+    # Should not raise.
+    _write_profile_record(
+        dest,
+        request=request,
+        host_timings={"init_seconds": 0.0},
+        meta_text=None,
+        response=None,
+    )
+    assert not Path(dest).exists()
+
+
+def test_runner_emits_profile_event_unconditionally(tmp_path):
+    """Even with profiling off, the worker still emits a profile event.
+
+    This is the property the host-side writer relies on: profiling is
+    enabled by setting an env var on the host, and the worker emits
+    checkpoints whether or not anyone is listening (the cost is ~250 ns
+    per ``perf_counter`` call -- well below any timing we care about).
+    """
+    # Build a real frame the way the worker would, and feed it through
+    # the runner -- the runner just decodes it.
+    profile_event = Event(
+        type="profile",
+        checkpoints=[("enter", 0.0), ("completed", 0.001)],
+    )
+    fake = FakeIsolate(
+        run_stdout=_make_response_bytes(
+            events=(Event(type="return", value=7), profile_event),
+        ),
+    )
+    runner = _make_runner(fake)
+    resp = runner.run(_request(str(tmp_path)))
+    profile_events = [e for e in resp.events if e.type == "profile"]
+    assert len(profile_events) == 1
+    assert profile_events[0].checkpoints[0] == ["enter", 0.0]
+
+
+def test_runner_writes_profile_line_when_env_set(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """End-to-end: env var set -> one JSON line per ``run()``."""
+    dest = tmp_path / "profile.jsonl"
+    monkeypatch.setenv(PROFILE_ENV_VAR, str(dest))
+    fake = FakeIsolate(
+        run_stdout=_make_response_bytes(
+            events=(
+                Event(type="return", value=7),
+                Event(
+                    type="profile",
+                    checkpoints=[("enter", 0.0), ("completed", 0.001)],
+                ),
+            ),
+        ),
+        meta_text="time:0.01\ntime-wall:0.02\nmax-rss:2048\nexitcode:0\n",
+    )
+    runner = _make_runner(fake)
+    runner.run(_request(str(tmp_path)))
+    runner.run(_request(str(tmp_path)))
+    lines = dest.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    record = __import__("json").loads(lines[0])
+    assert set(record["host"]) == {
+        "init_seconds",
+        "run_seconds",
+        "cleanup_seconds",
+        "total_seconds",
+    }
+    # Non-negative timings -- ``perf_counter`` is monotonic.
+    assert all(v >= 0 for v in record["host"].values())
+    assert record["isolate"]["time"] == 0.01
+    assert record["worker"]["checkpoints"][-1] == ["completed", 0.001]
+
+
+def test_runner_skips_profile_write_when_env_unset(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """With no env var, the runner never opens the profile file."""
+    monkeypatch.delenv(PROFILE_ENV_VAR, raising=False)
+    dest = tmp_path / "profile.jsonl"
+    fake = FakeIsolate(
+        run_stdout=_make_response_bytes(events=(Event(type="return", value=7),)),
+    )
+    runner = _make_runner(fake)
+    runner.run(_request(str(tmp_path)))
+    assert not dest.exists()
+
+
+def test_runner_writes_profile_line_even_on_init_failure(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Partial timings are still useful when isolate --init fails."""
+    dest = tmp_path / "profile.jsonl"
+    monkeypatch.setenv(PROFILE_ENV_VAR, str(dest))
+    fake = FakeIsolate(
+        run_stdout=b"",
+        meta_text="",
+        init_returncode=1,
+        init_stderr="oops",
+    )
+    runner = _make_runner(fake)
+    with pytest.raises(SandboxException):
+        runner.run(_request(str(tmp_path)))
+    lines = dest.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = __import__("json").loads(lines[0])
+    # init ran (and recorded a timing); run / cleanup did not.
+    assert "init_seconds" in record["host"]
+    assert "run_seconds" not in record["host"]
+    assert "cleanup_seconds" not in record["host"]
+    assert "total_seconds" in record["host"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -147,10 +147,18 @@ def test_run_argv_includes_required_bind_mounts(tmp_path):
         meta_path="/tmp/meta.txt",
     )
     argv = plan.run_argv()
-    # /box/submission is RW and points at the request's submission_dir
-    assert f"/box/submission={tmp_path}:rw" in argv
-    # /box/grader is RO and points at the grader source
-    assert "/box/grader=/path/to/grader" in argv
+    # The mount targets are *relative* to the box root.  isolate
+    # refuses to create subdirectories in bound directories, so
+    # absolute paths like ``/box/submission`` would double-up the
+    # prefix and fail at mount time with ``Cannot mount ... on
+    # box/submission: Permission denied``.  Inside the sandbox the
+    # mounts still appear at ``/box/submission`` and ``/box/grader``
+    # because isolate exposes the box root at ``/box``.
+    assert f"submission={tmp_path}:rw" in argv
+    assert "grader=/path/to/grader" in argv
+    # Sanity: confirm we did NOT regress to the old absolute-path form.
+    assert f"/box/submission={tmp_path}:rw" not in argv
+    assert "/box/grader=/path/to/grader" not in argv
 
 
 def test_run_argv_sets_environment(tmp_path):
@@ -413,7 +421,7 @@ def test_runner_rewrites_submission_dir_in_frame_to_sandbox_path(tmp_path):
     run_argv = run_calls[0][0]
     bind_specs = [run_argv[i + 1] for i, a in enumerate(run_argv) if a == "--dir"]
     assert any(
-        spec.startswith("/box/submission=") and host_path in spec for spec in bind_specs
+        spec.startswith("submission=") and host_path in spec for spec in bind_specs
     )
 
 

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -383,6 +383,40 @@ def test_runner_writes_request_frame_to_worker_stdin(tmp_path):
     assert len(payload) == length
 
 
+def test_runner_rewrites_submission_dir_in_frame_to_sandbox_path(tmp_path):
+    """The host's ``submission_dir`` is rewritten to ``/box/submission``
+    before being serialized to the worker.  The host path is unreachable
+    inside the sandbox -- only the bind-mounted path exists -- so the
+    worker must receive the in-sandbox path or its ``os.chdir`` will
+    raise ``FileNotFoundError``.
+    """
+    import json
+
+    fake = FakeIsolate(
+        run_stdout=_make_response_bytes(events=(Event(type="return", value=1),)),
+    )
+    runner = _make_runner(fake)
+    host_path = str(tmp_path)
+    request = _request(host_path)
+    runner.run(request)
+
+    run_calls = [c for c in fake.calls if "--run" in c[0]]
+    stdin_bytes = run_calls[0][1]
+    newline_index = stdin_bytes.index(b"\n")
+    payload = stdin_bytes[newline_index + 1 :].decode("utf-8")
+    frame = json.loads(payload)
+    assert frame["submission_dir"] == "/box/submission"
+    # The original request must not have been mutated -- the host-side
+    # caller may still inspect it (e.g. for logging).
+    assert request.submission_dir == host_path
+    # And the bind mount in the run argv must still point at the host path.
+    run_argv = run_calls[0][0]
+    bind_specs = [run_argv[i + 1] for i, a in enumerate(run_argv) if a == "--dir"]
+    assert any(
+        spec.startswith("/box/submission=") and host_path in spec for spec in bind_specs
+    )
+
+
 def test_runner_returns_decoded_response_when_worker_succeeds(tmp_path):
     fake = FakeIsolate(
         run_stdout=_make_response_bytes(

--- a/tests/sandbox/test_worker_main.py
+++ b/tests/sandbox/test_worker_main.py
@@ -1,0 +1,159 @@
+"""Tests for the worker_main entry point and its runtime dispatcher.
+
+These tests exercise the ``worker_main.main`` entry point in-process
+via ``BytesIO`` buffers, plus the ``_dispatch_request`` helper that
+chooses a runtime based on ``Request.runtime``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+from generic_grader.sandbox import worker_main
+from generic_grader.sandbox.protocol import Request, Response, write_request
+
+
+def _write_request_bytes(request: Request) -> bytes:
+    buf = io.BytesIO()
+    write_request(buf, request)
+    return buf.getvalue()
+
+
+def _read_response_bytes(buf: bytes) -> dict:
+    # Same length-prefixed framing as `read_response`, but we don't
+    # want to depend on Response.from_dict semantics here -- the test
+    # asserts on the raw JSON shape.
+    newline = buf.index(b"\n")
+    length = int(buf[:newline])
+    payload = buf[newline + 1 : newline + 1 + length]
+    return json.loads(payload)
+
+
+# ---------------------------------------------------------------------------
+# Runtime dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_python_runtime_routes_to_python_run_request(monkeypatch):
+    """A python request goes to ``python_runtime.run_request``."""
+    request = Request(runtime="python", submission_dir="/tmp", module="m", obj_name="f")
+    sentinel = Response(events=[], exception=None, elapsed_seconds=1.5)
+    captured = {}
+
+    def _fake_python_run(req):
+        captured["request"] = req
+        return sentinel
+
+    monkeypatch.setattr(
+        "generic_grader.sandbox.python_runtime.run_request", _fake_python_run
+    )
+    out = worker_main._dispatch_request(request)
+    assert out is sentinel
+    assert captured["request"] is request
+
+
+def test_dispatch_octave_runtime_routes_to_octave_run_request(monkeypatch):
+    """An octave request goes to the Octave stub's ``run_request``."""
+    request = Request(runtime="octave", submission_dir="/tmp", module="m", obj_name="f")
+    sentinel = Response(events=[], exception=None, elapsed_seconds=2.5)
+    captured = {}
+
+    def _fake_octave_run(req):
+        captured["request"] = req
+        return sentinel
+
+    monkeypatch.setattr(
+        "generic_grader.sandbox.octave_runtime.run_request", _fake_octave_run
+    )
+    out = worker_main._dispatch_request(request)
+    assert out is sentinel
+    assert captured["request"] is request
+
+
+def test_dispatch_unknown_runtime_returns_structured_error():
+    request = Request(runtime="erlang", submission_dir="/tmp", module="m", obj_name="f")
+    response = worker_main._dispatch_request(request)
+    assert response.events == []
+    assert response.exception is not None
+    assert response.exception[0]["type"] == "UnknownRuntimeError"
+    assert "erlang" in response.exception[0]["message"]
+
+
+def test_dispatch_runtime_is_case_insensitive():
+    """``runtime='PYTHON'`` should still route to the Python worker."""
+    request = Request(runtime="PYTHON", submission_dir="/tmp", module="m", obj_name="f")
+
+    # The real python worker would need module resolution; we just
+    # confirm the dispatcher doesn't fall through to the error branch.
+    # The simplest signal: the exception (if any) is not the dispatch
+    # error -- it's whatever python_runtime produces (probably a
+    # ModuleNotFoundError for our fake module).
+    response = worker_main._dispatch_request(request)
+    if response.exception:
+        assert response.exception[0]["type"] != "UnknownRuntimeError"
+
+
+def test_dispatch_empty_runtime_string_is_treated_as_unknown():
+    request = Request(runtime="", submission_dir="/tmp", module="m", obj_name="f")
+    response = worker_main._dispatch_request(request)
+    assert response.exception is not None
+    assert response.exception[0]["type"] == "UnknownRuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# main(): framed I/O
+# ---------------------------------------------------------------------------
+
+
+def test_main_round_trips_a_python_request(monkeypatch):
+    """A valid request -> response, exit code 0."""
+    request = Request(runtime="python", submission_dir="/tmp", module="m", obj_name="f")
+    sentinel = Response(events=[], exception=None, elapsed_seconds=0.25)
+
+    def _fake_python_run(req):
+        return sentinel
+
+    monkeypatch.setattr(
+        "generic_grader.sandbox.python_runtime.run_request", _fake_python_run
+    )
+
+    stdin = io.BytesIO(_write_request_bytes(request))
+    stdout = io.BytesIO()
+    code = worker_main.main(stdin=stdin, stdout=stdout)
+    assert code == 0
+    payload = _read_response_bytes(stdout.getvalue())
+    assert payload["elapsed_seconds"] == 0.25
+    assert payload["events"] == []
+
+
+def test_main_returns_protocol_error_on_eof_before_frame():
+    """Empty stdin -> structured 'no request' error and exit code 2."""
+    stdin = io.BytesIO(b"")
+    stdout = io.BytesIO()
+    code = worker_main.main(stdin=stdin, stdout=stdout)
+    assert code == 2
+    payload = _read_response_bytes(stdout.getvalue())
+    assert payload["exception"][0]["type"] == "SandboxProtocolError"
+    assert "No request frame" in payload["exception"][0]["message"]
+
+
+def test_main_returns_protocol_error_on_malformed_frame():
+    """Garbage stdin -> structured protocol error and exit code 2."""
+    stdin = io.BytesIO(b"this is not a valid frame")
+    stdout = io.BytesIO()
+    code = worker_main.main(stdin=stdin, stdout=stdout)
+    assert code == 2
+    payload = _read_response_bytes(stdout.getvalue())
+    assert payload["exception"][0]["type"] == "SandboxProtocolError"
+
+
+def test_main_dispatches_unknown_runtime_via_dispatcher():
+    """An unknown runtime still produces exit code 0 (framed response wins)."""
+    request = Request(runtime="cobol", submission_dir="/tmp", module="m", obj_name="f")
+    stdin = io.BytesIO(_write_request_bytes(request))
+    stdout = io.BytesIO()
+    code = worker_main.main(stdin=stdin, stdout=stdout)
+    assert code == 0
+    payload = _read_response_bytes(stdout.getvalue())
+    assert payload["exception"][0]["type"] == "UnknownRuntimeError"

--- a/tests/utils/test_options.py
+++ b/tests/utils/test_options.py
@@ -124,3 +124,42 @@ def test_duplicate_file_names(case):
     with pytest.raises(ValueError) as exc_info:
         Options(**case["options"])
     assert str(exc_info.value) == case["error"]
+
+
+# ---------------------------------------------------------------------------
+# Sandbox opt-in (Layer 3)
+# ---------------------------------------------------------------------------
+
+
+def test_use_sandbox_defaults_to_false():
+    assert Options().use_sandbox is False
+    assert Options().patch_specs == ()
+
+
+def test_use_sandbox_alone_is_accepted():
+    """Opting into the sandbox with no patches is fine."""
+    Options(use_sandbox=True)
+
+
+def test_use_sandbox_with_patch_specs_is_accepted():
+    """`patch_specs` is the sandbox-safe way to ship patches."""
+    from generic_grader.sandbox.patch_specs import make_noop_patch_spec
+
+    Options(
+        use_sandbox=True,
+        patch_specs=(make_noop_patch_spec("m.f"),),
+    )
+
+
+def test_use_sandbox_rejects_legacy_patches_without_specs():
+    """Live callables in `patches` cannot cross the sandbox boundary."""
+    with pytest.raises(ValueError, match="patch_specs"):
+        Options(
+            use_sandbox=True,
+            patches=[{"args": ["m.f", lambda *a, **k: None]}],
+        )
+
+
+def test_legacy_patches_allowed_when_use_sandbox_false():
+    """Layer 1 (in-process) is unaffected by the new check."""
+    Options(patches=[{"args": ["m.f", lambda *a, **k: None]}])

--- a/tests/utils/test_options.py
+++ b/tests/utils/test_options.py
@@ -163,3 +163,25 @@ def test_use_sandbox_rejects_legacy_patches_without_specs():
 def test_legacy_patches_allowed_when_use_sandbox_false():
     """Layer 1 (in-process) is unaffected by the new check."""
     Options(patches=[{"args": ["m.f", lambda *a, **k: None]}])
+
+
+# ---------------------------------------------------------------------------
+# ref_dir (Layer 3)
+# ---------------------------------------------------------------------------
+
+
+def test_ref_dir_defaults_to_tests():
+    """`ref_dir` defaults to `./tests` so the recommended layout works
+    out of the box."""
+    assert Options().ref_dir == "./tests"
+
+
+def test_ref_dir_can_be_overridden():
+    """`ref_dir` is a writable string field."""
+    assert Options(ref_dir="./graders/foo").ref_dir == "./graders/foo"
+
+
+def test_ref_dir_must_be_a_string():
+    """Type validation rejects non-string values."""
+    with pytest.raises(ValueError, match="ref_dir"):
+        Options(ref_dir=123)


### PR DESCRIPTION
## Summary

Layer 3 of the grader security work (issue #98): every test can opt
in to running the student's code inside an
[isolate](https://github.com/ioi/isolate) sandbox.  PR #183 (Layer 1,
in-process blocklist) stays open as-is.

**Status**: ready for review.  The opt-in is `Options(use_sandbox=True)`;
with the flag off the grader behaves exactly as before.

## Commits

1. **`0038dee` — Sandbox package + IPC protocol.** Length-prefixed JSON
   framing, runtime-agnostic `Request` envelope, `Response` event log,
   structured exception chain.
2. **`4f45268` — Python runtime worker.** `run_request(request) -> Response`.
   stdout/stderr/stdin as ordered events; phase markers; tracebacks
   filtered to student frames only.
3. **`c4d54e5` — Matplotlib figure serializer.** JSON-safe schema covering
   every property `utils/plot.py` extracts.
4. **`809b77f` — `isolate` runner + worker entry point.** Split into pure
   `build_run_plan` / `parse_meta` / `classify_meta` plus an orchestrator
   with an injectable subprocess runner.
5. **`b99f830` — PatchSpec dataclass + `Options.use_sandbox` opt-in.**
   4 kinds: `noop`, `iter_returns`, `raise_error`, `source`.  Live
   callables in `patches` can't cross the boundary, so the opt-in
   validates that.
6. **`71452b7` — Address automated PR review feedback.**
7. **`1507283` — Worker-side patch reconstruction** with strict regex
   validation and a single `ExitStack` covering import + call.
8. **`d1d23a5` — Sandbox integration module.**  Thread-safe `BoxPool`,
   `SandboxRunResult`, event replay into LogIO/interactions,
   import/call outcome classification.
9. **`1b218b9` — Wire `Importer` / `User` to delegate to the sandbox.**
   `SANDBOX_OBJ_SENTINEL` as the opaque import-success token.  Preserves
   `AttributeError`, `EndOfInputError` ("Stuck at input"),
   `ModuleNotFoundError` with deepest-missing detection,
   `ExtraEntriesError`, `SafeKeyError` wrapping, `UserInitializationError`.
10. **`fc5a3c5` — `Options.ref_dir` + plot helpers consume serialized
    figures.** New `sandbox/figure_facade.py` adapts a serialized-figure
    dict to the slice of matplotlib's API that `utils/plot.py` reaches
    into, so `get_current_axes(test)` works unchanged.
11. **`c988d1d` — Octave runtime stub + worker-main dispatcher.**
    Unknown runtimes return a structured `UnknownRuntimeError` rather
    than an opaque crash.
12. **`4e151be` — ROADMAP and README.**  See note below about the CI
    workflow change.

## Design decisions (per our discussion)

1. **Sandbox tool**: `isolate` (no fallback). One-time setup is `sudo isolate --init`.
2. **Fresh sandbox per call.** Reference and submission each run in their own sandbox.
3. **One-shot framed JSON** in, one-shot framed JSON out.
4. **Plot tests serialize Figure properties**, not PNGs.
5. **Feature flag**: `Options(use_sandbox=False)` (default).  No behavior change for existing tests.
6. **Patches that need to cross the sandbox** must be expressed as `PatchSpec` instances.  Live callables can't be JSON-serialized.
7. **No networking.**
8. **Octave/MATLAB support**: stub today, real implementation later.
9. **Default captures**: `stdout`, `stderr`, `return`, `figures`, `exception`.
10. **Tracebacks filtered to student frames only** so grader internals never leak through exceptions.

## Tests

- **1023 passing, 1 skipped** (the skipped one is the real-isolate smoke
  test, which runs when `isolate` is on PATH).
- **100% line coverage** on every file added in this PR.
- `utils/importer.py` (98%) and `utils/user.py` (99%) carry only their
  pre-existing uncovered legacy branches; no new uncovered code.

## CI note

`.github/workflows/pytest.yml` needs a one-line update to add `isolate`
to its `apt install` line.  The bot account that authored this branch
does not have GitHub's `workflow` token scope, so a maintainer needs to
apply that change.  The README's isolate-install step calls this out
explicitly.

## How to review

Each commit is self-contained.  The recommended reading order is the
commit list above, but `protocol.py` (1) and `python_runtime.py` (2)
together describe the entire sandbox API surface; everything else
bolts onto those two.